### PR TITLE
Feature/dockstore 193 entry validation

### DIFF
--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -19,6 +19,9 @@ angular.module('dockstore.ui')
       $scope.labelsEditMode = false;
       $scope.dockerfileEnabled = false;
       $scope.descriptorEnabled = false;
+      $scope.validContent = true;
+      $scope.missingContent = [];
+      $scope.missingWarning = false;
       $scope.showEditCWL = true;
       $scope.showEditWDL = true;
       $scope.showEditDockerfile = true;
@@ -124,6 +127,44 @@ angular.module('dockstore.ui')
           ).finally(function(response) {
             $scope.refreshingContainer = false;
           });
+      };
+
+      $scope.checkContentValid = function(){
+        //will print this when the 'Publish' button is clicked
+        var message = 'The file is missing some required fields. Please make sure the file has all the required fields. ';
+        var missingMessage = 'The missing field(s):'
+        if($scope.validContent){
+          if($scope.missingContent.length !== 0){
+            $scope.missingWarning = true;
+          }
+          return true;
+
+        } else{
+            if($scope.missingContent.length !== 0){
+              $scope.missingWarning = false;
+              for(var i=0;i<$scope.missingContent.length;i++){
+                missingMessage += ' \''+$scope.missingContent[i]+'\'';
+                if(i!=$scope.missingContent.length -1){
+                  missingMessage+=',';
+                }
+              }
+              if(!$scope.refreshingWorkflow){
+                if($scope.containerObj.descriptorType === 'wdl'){
+                  $scope.setContainerDetailsError(
+                    message+missingMessage +
+                    '. Required fields in WDL file: \'task\', \'workflow\', \'call\', \'command\', and \'output\'',''
+                  );
+                }else{
+                  $scope.setContainerDetailsError(
+                    message+missingMessage +
+                    '. Required fields in CWL file: \'inputs\', \'outputs\', \'class\', and \'baseCommand\'',''
+                  );
+                }
+              }
+            }
+
+          return false;
+        }
       };
 
       $scope.setDefaultCWLPath = function(containerId, cwlpath){
@@ -391,6 +432,25 @@ angular.module('dockstore.ui')
               $scope.labelsEditMode = false;
             });
         }
+      };
+
+      $scope.isContainerValid = function() {
+        if ($scope.containerObj.is_published) {
+          return true;
+        }
+
+        var versionTags = $scope.containerObj.tags;
+
+        if (versionTags === null) {
+          return false;
+        }
+
+        for (var i = 0; i < versionTags.length; i++) {
+          if (versionTags[i].valid) {
+            return true;
+          }
+        }
+        return false;
       };
 
       $scope.$watch('containerPath', function(newValue, oldValue) {

--- a/app/scripts/controllers/containerfileviewer.js
+++ b/app/scripts/controllers/containerfileviewer.js
@@ -28,15 +28,11 @@ angular.module('dockstore.ui')
         $scope.fileContent = null;
         var accumulator = [];
         var index = 0;
-        var inputFound = false;
-        var outputFound = false;
-        var classFound = false;
-        var taskFound = false;
-        var workflowFound = false;
-        var commandFound = false;
-        var callFound = false;
         var m = [];
         var v = false;
+        var count = 0;
+        var cwlFields = ["inputs","outputs","baseCommand","class"];
+        var wdlFields = ["task","output","workflow","command","call"];
         for (var i=0; i<$scope.containerTags.length; i++) {
           for (var j=0; j<descriptors.length; j++) {
             accumulator[index] = {
@@ -86,76 +82,38 @@ angular.module('dockstore.ui')
             $scope.selTagName = $scope.successContent[0].tag;
             $scope.selDescriptorName = $scope.successContent[0].descriptor;
             $scope.fileContent = $scope.successContent[0].content;
-            var result = $scope.fileContent.toLowerCase();
+            var result = $scope.fileContent;
             m = [];
             v = false;
+            count = 0;
             if($scope.selDescriptorName === "cwl"){
               //Descriptor: CWL
-              if(result.search("inputs:") !== -1){
-                inputFound = true;
-              }else{
-                m.push('inputs');
+              for(var i=0;i<cwlFields.length;i++){
+                if(result.search(cwlFields[i]) !==-1){
+                  count++;
+                } else{
+                  m.push(cwlFields[i]);
+                }
+              }
+              if(result.search("cwlVersion:")===-1){
+                m.push('cwlVersion');
               }
 
-              if(result.search("outputs:") !== -1){
-                outputFound = true;
-              }else{
-                m.push('outputs');
-              }
-
-              if(result.search("basecommand:") !== -1){
-                commandFound = true;
-              }else{
-                m.push('baseCommand');
-              }
-
-              if(result.search("class:") !== -1){
-                classFound = true;
-              }else{
-                m.push('class');
-              }
-
-              if(inputFound && outputFound && classFound && commandFound){
+              if(count===4){
                 v = true;
-              } else{
-                v = false;
               }
             } else{
               //Descriptor: WDL
-              if(result.search('task') !== -1){
-                taskFound = true;
-              }else{
-                m.push('task');
+              for(var i=0;i<wdlFields.length;i++){
+                if(result.search(wdlFields[i]) !==-1){
+                  count++;
+                } else{
+                  m.push(wdlFields[i]);
+                }
               }
 
-              if(result.search('workflow') !== -1){
-                workflowFound = true;
-              }else{
-                m.push('workflow');
-              }
-
-              if(result.search('call') !== -1){
-                callFound = true;
-              }else{
-                m.push('call');
-              }
-
-              if(result.search('command') !== -1){
-                commandFound = true;
-              }else{
-                m.push('command');
-              }
-
-              if(result.search('output') !== -1){
-                outputFound = true;
-              }else{
-                m.push('output');
-              }
-
-              if(taskFound && workflowFound && commandFound && callFound && outputFound){
+              if(count===5){
                 v = true;
-              } else{
-                v = false;
               }
             }
             $scope.$emit('returnMissing',m);

--- a/app/scripts/controllers/containerfileviewer.js
+++ b/app/scripts/controllers/containerfileviewer.js
@@ -9,26 +9,41 @@
  */
 angular.module('dockstore.ui')
   .controller('ContainerFileViewerCtrl', [
-  	'$scope',
+    '$scope',
     '$q',
     'ContainerService',
     'NotificationService',
-  	function ($scope, $q, ContainerService, NtfnService) {
+    function ($scope, $q, ContainerService, NtfnService) {
 
       var descriptors = ["cwl", "wdl"];
 
       $scope.fileLoaded = false;
       $scope.fileContents = null;
       $scope.successContent = [];
+      $scope.fileContent = null;
 
       $scope.checkDescriptor = function() {
         $scope.containerTags = $scope.getContainerTags();
         $scope.successContent = [];
+        $scope.fileContent = null;
         var accumulator = [];
         var index = 0;
+        var inputFound = false;
+        var outputFound = false;
+        var classFound = false;
+        var taskFound = false;
+        var workflowFound = false;
+        var commandFound = false;
+        var callFound = false;
+        var m = [];
+        var v = false;
         for (var i=0; i<$scope.containerTags.length; i++) {
           for (var j=0; j<descriptors.length; j++) {
-            accumulator[index] = {tag: $scope.containerTags[i], desc: descriptors[j]};
+            accumulator[index] = {
+              tag: $scope.containerTags[i],
+              desc: descriptors[j],
+              content: null
+            };
             index++;
           };
         };
@@ -39,7 +54,11 @@ angular.module('dockstore.ui')
             function filePromise(vd){
               return $scope.getDescriptorFile($scope.containerObj.id, vd.tag, vd.desc).then(
                 function(s){
-                  $scope.successContent.push({tag:vd.tag,descriptor:vd.desc});
+                  $scope.successContent.push({
+                    tag:vd.tag,
+                    descriptor:vd.desc,
+                    content:s
+                  });
                   if(start+1 === acc.length) {
                     return {success: true, index:start};
                   } else{
@@ -66,6 +85,81 @@ angular.module('dockstore.ui')
           function(result){
             $scope.selTagName = $scope.successContent[0].tag;
             $scope.selDescriptorName = $scope.successContent[0].descriptor;
+            $scope.fileContent = $scope.successContent[0].content;
+            var result = $scope.fileContent.toLowerCase();
+            m = [];
+            v = false;
+            if($scope.selDescriptorName === "cwl"){
+              //Descriptor: CWL
+              if(result.search("inputs:") !== -1){
+                inputFound = true;
+              }else{
+                m.push('inputs');
+              }
+
+              if(result.search("outputs:") !== -1){
+                outputFound = true;
+              }else{
+                m.push('outputs');
+              }
+
+              if(result.search("basecommand:") !== -1){
+                commandFound = true;
+              }else{
+                m.push('baseCommand');
+              }
+
+              if(result.search("class:") !== -1){
+                classFound = true;
+              }else{
+                m.push('class');
+              }
+
+              if(inputFound && outputFound && classFound && commandFound){
+                v = true;
+              } else{
+                v = false;
+              }
+            } else{
+              //Descriptor: WDL
+              if(result.search('task') !== -1){
+                taskFound = true;
+              }else{
+                m.push('task');
+              }
+
+              if(result.search('workflow') !== -1){
+                workflowFound = true;
+              }else{
+                m.push('workflow');
+              }
+
+              if(result.search('call') !== -1){
+                callFound = true;
+              }else{
+                m.push('call');
+              }
+
+              if(result.search('command') !== -1){
+                commandFound = true;
+              }else{
+                m.push('command');
+              }
+
+              if(result.search('output') !== -1){
+                outputFound = true;
+              }else{
+                m.push('output');
+              }
+
+              if(taskFound && workflowFound && commandFound && callFound && outputFound){
+                v = true;
+              } else{
+                v = false;
+              }
+            }
+            $scope.$emit('returnMissing',m);
+            $scope.$emit('returnValid',v);
           },
           function(e){console.log("error",e)}
         );

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -307,7 +307,7 @@ angular.module('dockstore.ui')
         $scope.labelsEditMode = !$scope.labelsEditMode;
       };
 
-      $scope.submitWorkflowPathEdits = function(type){
+      $scope.submitWorkflowPathEdits = function(){
         if($scope.workflowObj.workflow_path !== 'undefined'){
           $scope.setDefaultWorkflowPath($scope.workflowObj.id,
             $scope.workflowObj.workflow_path)

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -18,6 +18,9 @@ angular.module('dockstore.ui')
 
       $scope.labelsEditMode = false;
       $scope.descriptorEnabled = false;
+      $scope.validContent = true;
+      $scope.missingContent = [];
+      $scope.missingWarning = false;
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
         for (var i = 0; i < 3; i++) $scope.activeTabs.push(false);
@@ -99,6 +102,44 @@ angular.module('dockstore.ui')
           ).finally(function(response) {
             $scope.refreshingWorkflow = false;
           });
+      };
+
+      $scope.checkContentValid = function(){
+        //will print this when the 'Publish' button is clicked
+        var message = 'The file is missing some required fields. Please make sure the file has all the required fields. ';
+        var missingMessage = 'The missing field(s):'
+        if($scope.validContent){
+          if($scope.missingContent.length !== 0){
+            $scope.missingWarning = true;
+          }
+          return true;
+
+        } else{
+            if($scope.missingContent.length !== 0){
+              $scope.missingWarning = false;
+              for(var i=0;i<$scope.missingContent.length;i++){
+                missingMessage += ' \''+$scope.missingContent[i]+'\'';
+                if(i!=$scope.missingContent.length -1){
+                  missingMessage+=',';
+                }
+              }
+              if(!$scope.refreshingWorkflow){
+                if($scope.workflowObj.descriptorType === 'wdl'){
+                  $scope.setWorkflowDetailsError(
+                    message+missingMessage +
+                    '. Required fields in WDL file: \'task\', \'workflow\', \'call\', \'command\', and \'output\'',''
+                  );
+                }else{
+                  $scope.setWorkflowDetailsError(
+                    message+missingMessage +
+                    '. Required fields in CWL file: \'inputs\', \'outputs\', \'class\', and \'steps\'',''
+                  );
+                }
+              }
+            }
+
+          return false;
+        }
       };
 
       $scope.setDefaultWorkflowPath = function(workflowId, path){

--- a/app/scripts/controllers/workflowfileviewer.js
+++ b/app/scripts/controllers/workflowfileviewer.js
@@ -28,16 +28,11 @@ angular.module('dockstore.ui')
         $scope.fileContent = null;
         var accumulator = [];
         var index = 0;
-        var inputFound = false;
-        var outputFound = false;
-        var stepsFound = false;
-        var classFound = false;
-        var taskFound = false;
-        var workflowFound = false;
-        var commandFound = false;
-        var callFound = false;
         var m = [];
         var v = false;
+        var count = 0;
+        var cwlFields = ["inputs","outputs","steps","class"];
+        var wdlFields = ["task","output","workflow","command","call"];
         for (var i=0; i<$scope.workflowVersions.length; i++) {
           for (var j=0; j<descriptors.length; j++) {
             accumulator[index] = {
@@ -87,76 +82,38 @@ angular.module('dockstore.ui')
             $scope.selVersionName = $scope.successContent[0].version;
             $scope.selDescriptorName = $scope.successContent[0].descriptor;
             $scope.fileContent = $scope.successContent[0].content;
-            var result = $scope.fileContent.toLowerCase();
+            var result = $scope.fileContent;
             m = [];
             v = false;
+            count = 0;
             if($scope.selDescriptorName === "cwl"){
               //Descriptor: CWL
-              if(result.search("inputs:") !== -1){
-                inputFound = true;
-              }else{
-                m.push('inputs');
+              for(var i=0;i<cwlFields.length;i++){
+                if(result.search(cwlFields[i]) !==-1){
+                  count++;
+                } else{
+                  m.push(cwlFields[i]);
+                }
+              }
+              if(result.search("cwlVersion:")===-1){
+                m.push('cwlVersion');
               }
 
-              if(result.search("outputs:") !== -1){
-                outputFound = true;
-              }else{
-                m.push('outputs');
-              }
-
-              if(result.search("steps:") !== -1){
-                stepsFound = true;
-              }else{
-                m.push('steps');
-              }
-
-              if(result.search("class:") !== -1){
-                classFound = true;
-              }else{
-                m.push('class');
-              }
-
-              if(inputFound && outputFound && classFound && stepsFound){
+              if(count===4){
                 v = true;
-              } else{
-                v = false;
               }
             } else{
               //Descriptor: WDL
-              if(result.search('task') !== -1){
-                taskFound = true;
-              }else{
-                m.push('task');
+              for(var i=0;i<wdlFields.length;i++){
+                if(result.search(wdlFields[i]) !==-1){
+                  count++;
+                } else{
+                  m.push(wdlFields[i]);
+                }
               }
 
-              if(result.search('workflow') !== -1){
-                workflowFound = true;
-              }else{
-                m.push('workflow');
-              }
-
-              if(result.search('call') !== -1){
-                callFound = true;
-              }else{
-                m.push('call');
-              }
-
-              if(result.search('command') !== -1){
-                commandFound = true;
-              }else{
-                m.push('command');
-              }
-
-              if(result.search('output') !== -1){
-                outputFound = true;
-              }else{
-                m.push('output');
-              }
-
-              if(taskFound && workflowFound && commandFound && callFound && outputFound){
+              if(count===5){
                 v = true;
-              } else{
-                v = false;
               }
             }
             $scope.$emit('returnMissing',m);

--- a/app/scripts/controllers/workflowfileviewer.js
+++ b/app/scripts/controllers/workflowfileviewer.js
@@ -9,26 +9,42 @@
  */
 angular.module('dockstore.ui')
   .controller('WorkflowFileViewerCtrl', [
-  	'$scope',
+    '$scope',
     '$q',
     'WorkflowService',
     'NotificationService',
-  	function ($scope, $q, WorkflowService, NtfnService) {
+    function ($scope, $q, WorkflowService, NtfnService) {
 
       var descriptors = ["cwl", "wdl"];
 
       $scope.fileLoaded = false;
       $scope.fileContents = null;
       $scope.successContent = [];
+      $scope.fileContent = null;
 
       $scope.checkDescriptor = function() {
         $scope.workflowVersions = $scope.getWorkflowVersions();
         $scope.successContent = [];
+        $scope.fileContent = null;
         var accumulator = [];
         var index = 0;
+        var inputFound = false;
+        var outputFound = false;
+        var stepsFound = false;
+        var classFound = false;
+        var taskFound = false;
+        var workflowFound = false;
+        var commandFound = false;
+        var callFound = false;
+        var m = [];
+        var v = false;
         for (var i=0; i<$scope.workflowVersions.length; i++) {
           for (var j=0; j<descriptors.length; j++) {
-            accumulator[index] = {ver: $scope.workflowVersions[i], desc: descriptors[j]};
+            accumulator[index] = {
+              ver: $scope.workflowVersions[i], 
+              desc: descriptors[j], 
+              content: null
+            };
             index++;
           };
         };
@@ -39,7 +55,11 @@ angular.module('dockstore.ui')
             function filePromise(vd){
               return $scope.getDescriptorFile($scope.workflowObj.id, vd.ver, vd.desc).then(
                 function(s){
-                  $scope.successContent.push({version:vd.ver,descriptor:vd.desc});
+                  $scope.successContent.push({
+                    version:vd.ver,
+                    descriptor:vd.desc,
+                    content: s
+                  });
                   if(start+1 === acc.length) {
                     return {success: true, index:start};
                   } else{
@@ -66,6 +86,81 @@ angular.module('dockstore.ui')
           function(result){
             $scope.selVersionName = $scope.successContent[0].version;
             $scope.selDescriptorName = $scope.successContent[0].descriptor;
+            $scope.fileContent = $scope.successContent[0].content;
+            var result = $scope.fileContent.toLowerCase();
+            m = [];
+            v = false;
+            if($scope.selDescriptorName === "cwl"){
+              //Descriptor: CWL
+              if(result.search("inputs:") !== -1){
+                inputFound = true;
+              }else{
+                m.push('inputs');
+              }
+
+              if(result.search("outputs:") !== -1){
+                outputFound = true;
+              }else{
+                m.push('outputs');
+              }
+
+              if(result.search("steps:") !== -1){
+                stepsFound = true;
+              }else{
+                m.push('steps');
+              }
+
+              if(result.search("class:") !== -1){
+                classFound = true;
+              }else{
+                m.push('class');
+              }
+
+              if(inputFound && outputFound && classFound && stepsFound){
+                v = true;
+              } else{
+                v = false;
+              }
+            } else{
+              //Descriptor: WDL
+              if(result.search('task') !== -1){
+                taskFound = true;
+              }else{
+                m.push('task');
+              }
+
+              if(result.search('workflow') !== -1){
+                workflowFound = true;
+              }else{
+                m.push('workflow');
+              }
+
+              if(result.search('call') !== -1){
+                callFound = true;
+              }else{
+                m.push('call');
+              }
+
+              if(result.search('command') !== -1){
+                commandFound = true;
+              }else{
+                m.push('command');
+              }
+
+              if(result.search('output') !== -1){
+                outputFound = true;
+              }else{
+                m.push('output');
+              }
+
+              if(taskFound && workflowFound && commandFound && callFound && outputFound){
+                v = true;
+              } else{
+                v = false;
+              }
+            }
+            $scope.$emit('returnMissing',m);
+            $scope.$emit('returnValid',v);
           },
           function(e){console.log("error",e)}
         );

--- a/app/scripts/directives/containerdetails.js
+++ b/app/scripts/directives/containerdetails.js
@@ -24,6 +24,13 @@ angular.module('dockstore.ui')
         scope.$on('tagEditorRefreshContainer', function(event, containerId) {
           scope.refreshContainer(containerId, 2);
         });
+        scope.$on('returnValid', function(event, valid){
+          scope.validContent = valid;
+          scope.checkContentValid();
+        });
+        scope.$on('returnMissing', function(event,missing){
+          scope.missingContent = missing;
+        });
       }
     };
   });

--- a/app/scripts/directives/workflowdetails.js
+++ b/app/scripts/directives/workflowdetails.js
@@ -24,6 +24,13 @@ angular.module('dockstore.ui')
         scope.$on('versionTagEditorRefreshWorkflow', function(event, workflowId) {
           scope.refreshWorkflow(workflowId, 2);
         });
+        scope.$on('returnValid', function(event, valid){
+          scope.validContent = valid;
+          scope.checkContentValid();
+        });
+        scope.$on('returnMissing', function(event,missing){
+          scope.missingContent = missing;
+        });
       }
     };
   });

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -148,7 +148,7 @@ angular.module('dockstore.ui')
           reject(response);
         });
       });
-    }
+    };
 
     this.setWorkflowLabels = function(workflowId, labels) {
       return $q(function(resolve, reject) {

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -1,4 +1,4 @@
-<div class="row" ng-if="containerDetailsError || refreshingContainer">
+<div class="row" ng-if="containerDetailsError || refreshingContainer || missingWarning">
   <div class="col-md-12">
     <div class="alert alert-danger alert-dismissable"
         ng-class="!editMode ? 'push-top' : ''"
@@ -23,6 +23,23 @@
       </span>
       Please wait, retrieving {{imageReposProviderName}} container...
     </div>
+    <div class="alert alert-warning"
+         ng-class="!editMode ? 'push-top' : ''"
+         role="alert"
+         ng-if="missingWarning"
+         >
+      <button type="button"
+              class="close"
+              data-dismiss="alert"
+              ng-click="missingWarning = false">
+        &times;
+      </button>
+      <span class="glyphicon glyphicon-warning-sign">
+      </span>
+      {{ missingContent.length === 1 ? 'Field that is missing from file: ' : 'Fields that are missing from file: '}}
+      {{missingContent}}
+    </div>
+  </div>
   </div>
 </div>
 <div class="row" ng-show="containerObj">
@@ -66,10 +83,11 @@
           <button uib-btn-checkbox
               type="button"
               class="btn btn-primary"
-              ng-click="setContainerRegistration(containerObj.id, containerObj.is_published)"
+              ng-class="!refreshingContainer && isContainerValid()? '' : 'disabled'"
+              ng-click="setContainerRegistration(containerObj.id, containerObj.is_published); checkContentValid()"
               ng-model="containerObj.is_published"
               ng-class="containerObj.is_published ? 'btn-primary' : 'btn-warning'"
-              ng-disabled="refreshingContainer">
+              ng-disabled="refreshingContainer || !isContainerValid() || !validContent">
             {{ containerObj.is_published ? 'Unpublish' : 'Publish' }}
           </button>
           <button type="button"
@@ -81,7 +99,7 @@
         </div>
         <button type="button"
             class="btn btn-primary"
-            ng-click="refreshContainer(containerObj.id)"
+            ng-click="refreshContainer(containerObj.id);checkPage()"
             ng-disabled="refreshingContainer">
           Refresh
         </button>
@@ -169,6 +187,51 @@
             </span>
           </li>
           <li>
+            <div ng-show="editMode && showEditDockerfile">
+              <strong>Dockerfile Path</strong>:
+              {{containerObj.default_dockerfile_path}}
+              <button type="sbutton"
+                  class="btn btn-link pull-right"
+                  style="padding: 3px 12px!important;"
+                  ng-click="showEditDockerfile = false">
+                <span class="glyphicon glyphicon-edit"></span>Edit
+              </button>
+            </div>
+            <form name="editContainerForm"
+                  class="edit-container form-inline"
+                  ng-show="editMode && !showEditDockerfile"
+                  ng-submit="submitDescriptorEdits('dockerfile')">
+              <button type="submit"
+                      class="btn btn-link pull-right"
+                      style="padding: 3px 12px!important;"
+                      ng-click="showEditDockerfile = true"
+                      ng-disabled="editContainerForm.$invalid">
+                <span class="glyphicon glyphicon-floppy-save"></span>Save
+              </button>
+              <div ng-show="!showEditDockerfile">
+              <strong>Dockerfile Path</strong>:
+                <div class="form-group">
+                  <input
+                      type="text"
+                      class="input-default form-control"
+                      name="contDescPath"
+                      ng-model="containerObj.default_dockerfile_path"
+                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*Dockerfile$/i"
+                      ng-minlength="3"
+                      ng-maxlength="256"
+                      placeholder="e.g. /Dockerfile" />
+                  <div
+                      class="form-error-messages"
+                      ng-messages="editContainerForm.contLabels.$error"
+                      ng-if="editContainerForm.contLabels.$touched">
+                    <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </li>
+          <li>
             <div ng-show="editMode && showEditCWL">
               <strong>CWL Path</strong>:
               {{containerObj.default_cwl_path}}
@@ -252,51 +315,6 @@
                       ng-messages="editContainerForm.contLabels.$error"
                       ng-if="editContainerForm.contLabels.$touched">
                     <div ng-messages-include="templates/validation/containers/descriptorpath.html">
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </form>
-          </li>
-          <li>
-            <div ng-show="editMode && showEditDockerfile">
-              <strong>Dockerfile Path</strong>:
-              {{containerObj.default_dockerfile_path}}
-              <button type="sbutton"
-                  class="btn btn-link pull-right"
-                  style="padding: 3px 12px!important;"
-                  ng-click="showEditDockerfile = false">
-                <span class="glyphicon glyphicon-edit"></span>Edit
-              </button>
-            </div>
-            <form name="editContainerForm"
-                  class="edit-container form-inline"
-                  ng-show="editMode && !showEditDockerfile"
-                  ng-submit="submitDescriptorEdits('dockerfile')">
-              <button type="submit"
-                      class="btn btn-link pull-right"
-                      style="padding: 3px 12px!important;"
-                      ng-click="showEditDockerfile = true"
-                      ng-disabled="editContainerForm.$invalid">
-                <span class="glyphicon glyphicon-floppy-save"></span>Save
-              </button>
-              <div ng-show="!showEditDockerfile">
-              <strong>Dockerfile Path</strong>:
-                <div class="form-group">
-                  <input
-                      type="text"
-                      class="input-default form-control"
-                      name="contDescPath"
-                      ng-model="containerObj.default_dockerfile_path"
-                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*Dockerfile$/i"
-                      ng-minlength="3"
-                      ng-maxlength="256"
-                      placeholder="e.g. /Dockerfile" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
                     </div>
                   </div>
                 </div>

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -1,4 +1,4 @@
-<div class="row" ng-if="workflowDetailsError || refreshingWorkflow">
+<div class="row" ng-if="workflowDetailsError || refreshingWorkflow || missingWarning">
   <div class="col-md-12">
     <div class="alert alert-danger alert-dismissable"
          ng-class="!editMode ? 'push-top' : ''"
@@ -22,6 +22,22 @@
       <span class="glyphicon glyphicon-refresh glyphicon-refresh-animate">
       </span>
       Please wait, retrieving workflow...
+    </div>
+    <div class="alert alert-warning"
+         ng-class="!editMode ? 'push-top' : ''"
+         role="alert"
+         ng-if="missingWarning"
+         >
+      <button type="button"
+              class="close"
+              data-dismiss="alert"
+              ng-click="missingWarning = false">
+        &times;
+      </button>
+      <span class="glyphicon glyphicon-warning-sign">
+      </span>
+      {{ missingContent.length === 1 ? 'Field that is missing from file: ' : 'Fields that are missing from file: '}}
+      {{missingContent}}
     </div>
   </div>
 </div>
@@ -64,20 +80,22 @@
           <button uib-btn-checkbox
                   type="button"
                   class="btn btn-primary"
-                  ng-class="!refreshingWorkflow && isWorkflowValid() ? '' : 'disabled'"
-                  ng-click="setWorkflowRegistration(workflowObj.id, workflowObj.is_published)"
+                  ng-class="!refreshingWorkflow && isWorkflowValid()? '' : 'disabled'"
+                  ng-click="setWorkflowRegistration(workflowObj.id, workflowObj.is_published); checkContentValid()"
                   ng-model="workflowObj.is_published"
-                  ng-class="workflowObj.is_published ? 'btn-primary' : 'btn-warning'"
-                  ng-disabled="refreshingWorkflow || !isWorkflowValid()">
+                  ng-class="workflowObj.is_published? 'btn-primary' : 'btn-warning'"
+                  ng-disabled="refreshingWorkflow || !isWorkflowValid() || workflowObj.mode === 'STUB' || !validContent">
             {{ workflowObj.is_published ? 'Unpublish' : 'Publish' }}
           </button>
         </div>
+
         <button type="button"
                 class="btn btn-primary"
-                ng-click="refreshWorkflow(workflowObj.id)"
+                ng-click="refreshWorkflow(workflowObj.id); checkPage()"
                 ng-disabled="refreshingWorkflow">
           Refresh
         </button>
+
       </div>
     </h3>
   </div>


### PR DESCRIPTION
This pull request is related to issue #193: ga4gh/dockstore#193
Validation check is added on both tool and workflow. If the file failed the validation check, it will give a RED error message on the top, describing what's missing on the file. The 'Publish' button will be disabled since it's invalid to publish an invalid file. Feature is implemented everytime a workflow/tool is chosen, which then will "refresh" the validation check everytime. However, if the user made any changes to the file(i.e correcting what's missing from the file), the user must refresh the tool/workflow by hitting 'Refresh all workflows/tools' button, or else, the page wont be updated by the new changes.

NOTE: Issue #183 (ga4gh/dockstore#183) doesnt really exist anymore, cause the Publish button will not be clickable at all if the file is invalid.