### PR TITLE
Feature/dockstore 278 edit descriptor dropdown

### DIFF
--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -127,7 +127,9 @@ angular.module('dockstore.ui')
       };
 
       $scope.setDescriptorType = function(workflowId){
-        return WorkflowService.setDescriptorType(workflowId, $scope.workflowObj.workflow_path, $scope.workflowObj.workflowName, 
+        //we are calling setDefaultWorkflowPath because PUT in this service will also change the descriptor type
+        //and required to change the same values as when changing the default path
+        return WorkflowService.setDefaultWorkflowPath(workflowId, $scope.workflowObj.workflow_path, $scope.workflowObj.workflowName, 
           $scope.workflowObj.descriptorType, $scope.workflowObj.path, $scope.workflowObj.gitUrl)
           .then(
             function(workflowObj){

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -18,6 +18,8 @@ angular.module('dockstore.ui')
 
       $scope.labelsEditMode = false;
       $scope.descriptorEnabled = false;
+      $scope.showEditWorkflowPath = true;
+      $scope.showEditDescriptorType = true;
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
         for (var i = 0; i < 3; i++) $scope.activeTabs.push(false);
@@ -116,6 +118,27 @@ angular.module('dockstore.ui')
                 'for this workflow, please ensure that the path is valid, ' +
                 'properly-formatted and does not contain prohibited ' +
                 'characters of words.',
+                '[HTTP ' + response.status + '] ' + response.statusText + ': ' +
+                response.data
+              );
+              return $q.reject(response);
+            }
+          );
+      };
+
+      $scope.setDescriptorType = function(workflowId){
+        return WorkflowService.setDescriptorType(workflowId, $scope.workflowObj.workflow_path, $scope.workflowObj.workflowName, 
+          $scope.workflowObj.descriptorType, $scope.workflowObj.path, $scope.workflowObj.gitUrl)
+          .then(
+            function(workflowObj){
+              $scope.workflowObj.descriptorType = workflowObj.descriptorType;
+              $scope.updateWorkflowObj();
+              return workflowObj;
+            },
+            function(response) {
+              $scope.setWorkflowDetailsError(
+                'The webservice encountered an error trying to modify descriptor type ' +
+                'for this workflow.',
                 '[HTTP ' + response.status + '] ' + response.statusText + ': ' +
                 response.data
               );
@@ -250,6 +273,11 @@ angular.module('dockstore.ui')
             $scope.labelsEditMode = false;
           });
         }
+      };
+
+      $scope.submitDescriptorEdit = function() {
+        $scope.setDescriptorType($scope.workflowObj.id)
+          .then(function(workflowObj){console.log("success submit descriptor edit")});
       };
 
       $scope.submitWorkflowEdits = function() {

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -151,6 +151,26 @@ angular.module('dockstore.ui')
     }
 
     // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
+    this.setDescriptorType = function(workflowId, workflowpath, workflowname, descType,path, giturl) {
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'PUT',
+          url: WebService.API_URI + '/workflows/' + workflowId,
+          data: {
+            workflow_path: workflowpath,
+            workflowName: workflowname,
+            descriptorType: descType,
+            path: path,
+            gitUrl: giturl
+          }
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    }
+
     this.setWorkflowLabels = function(workflowId, labels) {
       return $q(function(resolve, reject) {
         $http({

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -150,27 +150,6 @@ angular.module('dockstore.ui')
       });
     }
 
-    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
-    this.setDescriptorType = function(workflowId, workflowpath, workflowname, descType,path, giturl) {
-      return $q(function(resolve, reject) {
-        $http({
-          method: 'PUT',
-          url: WebService.API_URI + '/workflows/' + workflowId,
-          data: {
-            workflow_path: workflowpath,
-            workflowName: workflowname,
-            descriptorType: descType,
-            path: path,
-            gitUrl: giturl
-          }
-        }).then(function(response) {
-          resolve(response.data);
-        }, function(response) {
-          reject(response);
-        });
-      });
-    }
-
     this.setWorkflowLabels = function(workflowId, labels) {
       return $q(function(resolve, reject) {
         $http({

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -169,6 +169,64 @@
             </span>
           </li>
           <li>
+          <!-- for when it's not edit mode-->
+            <div ng-show="!editMode">
+              <strong>Dockerfile Path</strong>:
+              {{containerObj.default_dockerfile_path}}
+            </div>
+          <!-- for when it's edit mode and Edit button not clicked-->
+            <div ng-show="editMode && showEditDockerfile">
+              <strong>Dockerfile Path</strong>:
+              {{containerObj.default_dockerfile_path}}
+              <button type="sbutton"
+                  class="btn btn-link pull-right"
+                  style="padding: 3px 12px!important;"
+                  ng-click="showEditDockerfile = false">
+                <span class="glyphicon glyphicon-edit"></span>Edit
+              </button>
+            </div>
+          <!-- for when it's edit mode and Edit button clicked-->
+            <form name="editContainerForm"
+                  class="edit-container form-inline"
+                  ng-show="editMode && !showEditDockerfile"
+                  ng-submit="submitDescriptorEdits('dockerfile')">
+              <button type="submit"
+                      class="btn btn-link pull-right"
+                      style="padding: 3px 12px!important;"
+                      ng-click="showEditDockerfile = true"
+                      ng-disabled="editContainerForm.$invalid">
+                <span class="glyphicon glyphicon-floppy-save"></span>Save
+              </button>
+              <div ng-show="!showEditDockerfile">
+              <strong>Dockerfile Path</strong>:
+                <div class="form-group">
+                  <input
+                      type="text"
+                      class="input-default form-control"
+                      name="contDescPath"
+                      ng-model="containerObj.default_dockerfile_path"
+                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*Dockerfile$/i"
+                      ng-minlength="3"
+                      ng-maxlength="256"
+                      placeholder="e.g. /Dockerfile" />
+                  <div
+                      class="form-error-messages"
+                      ng-messages="editContainerForm.contLabels.$error"
+                      ng-if="editContainerForm.contLabels.$touched">
+                    <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </li>
+          <li>
+          <!-- for when it's not edit mode-->
+            <div ng-show="!editMode">
+              <strong>CWL Path</strong>:
+              {{containerObj.default_cwl_path}}
+            </div>
+          <!-- for when it's edit mode and Edit button not clicked-->
             <div ng-show="editMode && showEditCWL">
               <strong>CWL Path</strong>:
               {{containerObj.default_cwl_path}}
@@ -179,6 +237,7 @@
                 <span class="glyphicon glyphicon-edit"></span>Edit
               </button>
             </div>
+            <!-- for when it's edit mode and Edit button clicked-->
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditCWL"
@@ -214,6 +273,12 @@
             </form>
           </li>
           <li>
+          <!-- for when it's not edit mode-->
+            <div ng-show="!editMode">
+              <strong>WDL Path</strong>:
+              {{containerObj.default_wdl_path}}
+            </div>
+          <!-- for when it's edit mode and Edit button not clicked-->
             <div ng-show="editMode && showEditWDL">
               <strong>WDL Path</strong>:
               {{containerObj.default_wdl_path}}
@@ -224,6 +289,7 @@
                 <span class="glyphicon glyphicon-edit"></span>Edit
               </button>
             </div>
+            <!-- for when it's edit mode and Edit button clicked-->
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditWDL"
@@ -252,51 +318,6 @@
                       ng-messages="editContainerForm.contLabels.$error"
                       ng-if="editContainerForm.contLabels.$touched">
                     <div ng-messages-include="templates/validation/containers/descriptorpath.html">
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </form>
-          </li>
-          <li>
-            <div ng-show="editMode && showEditDockerfile">
-              <strong>Dockerfile Path</strong>:
-              {{containerObj.default_dockerfile_path}}
-              <button type="sbutton"
-                  class="btn btn-link pull-right"
-                  style="padding: 3px 12px!important;"
-                  ng-click="showEditDockerfile = false">
-                <span class="glyphicon glyphicon-edit"></span>Edit
-              </button>
-            </div>
-            <form name="editContainerForm"
-                  class="edit-container form-inline"
-                  ng-show="editMode && !showEditDockerfile"
-                  ng-submit="submitDescriptorEdits('dockerfile')">
-              <button type="submit"
-                      class="btn btn-link pull-right"
-                      style="padding: 3px 12px!important;"
-                      ng-click="showEditDockerfile = true"
-                      ng-disabled="editContainerForm.$invalid">
-                <span class="glyphicon glyphicon-floppy-save"></span>Save
-              </button>
-              <div ng-show="!showEditDockerfile">
-              <strong>Dockerfile Path</strong>:
-                <div class="form-group">
-                  <input
-                      type="text"
-                      class="input-default form-control"
-                      name="contDescPath"
-                      ng-model="containerObj.default_dockerfile_path"
-                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*Dockerfile$/i"
-                      ng-minlength="3"
-                      ng-maxlength="256"
-                      placeholder="e.g. /Dockerfile" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
                     </div>
                   </div>
                 </div>

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -132,26 +132,35 @@
             </a>
           </li>
           <li>
-            <div ng-show="editMode && !labelsEditMode">
+          <!-- for when it's not edit mode-->
+            <div ng-show="!editMode">
+              <strong>Workflow Path</strong>:
+              {{workflowObj.workflow_path}}
+            </div>
+            
+          <!-- for when it's edit mode and Edit button not clicked-->
+            <div ng-show="editMode && showEditWorkflowPath">
               <strong>Workflow Path</strong>:
               {{workflowObj.workflow_path}}
               <button type="sbutton"
                   class="btn btn-link pull-right"
-                  ng-click="toggleLabelsEditMode()">
+                  ng-click="showEditWorkflowPath = false">
                 <span class="glyphicon glyphicon-edit"></span>Edit
               </button>
             </div>
+
+            <!-- for when it's edit mode and Edit button clicked-->
             <form name="editContainerForm"
                   class="edit-container form-inline"
-                  ng-show="editMode && labelsEditMode"
+                  ng-show="editMode && !showEditWorkflowPath"
                   ng-submit="submitWorkflowPathEdits()">
               <button type="submit"
                       class="btn btn-link pull-right"
-                      ng-click="toggleLabelsEditMode()"
+                      ng-click="showEditWorkflowPath = true"
                       ng-disabled="editContainerForm.$invalid">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
-              <div ng-show="labelsEditMode">
+              <div ng-show="!showEditWorkflowPath">
               <strong>Workflow Path</strong>:
                 <div class="form-group">
                   <input
@@ -174,13 +183,44 @@
               </div>
             </form>
           </li>
-          <li ng-if="editMode">
+          <li ng-show="editMode">
             <strong>Mode</strong>:
             {{workflowObj.mode | lowercase}}
           </li>
           <li>
+          <!-- when not in edit mode-->
+            <div ng-show="!editMode">
+              <Strong>Descriptor Type</Strong>:
+              {{workflowObj.descriptorType | lowercase}}
+            </div>
+          <!-- when in edit mode and Edit button for descriptor not clicked-->
+            <div ng-show="editMode && showEditDescriptorType">
             <Strong>Descriptor Type</Strong>:
             {{workflowObj.descriptorType | lowercase}}
+            <button type="sbutton"
+                  class="btn btn-link pull-right"
+                  style="padding: 3px 12px!important;"
+                  ng-click="showEditDescriptorType = false">
+                <span class="glyphicon glyphicon-edit"></span>Edit
+              </button>
+            </div>
+          <!-- when in edit mode and Edit button for descriptor is clicked-->
+            <div ng-show="editMode && !showEditDescriptorType">
+            <Strong>Descriptor Type</Strong>:
+              <select
+                ng-model="workflowObj.descriptorType"
+                ng-change="submitDescriptorEdit()">
+              <option value="cwl">cwl</option>
+              <option value="wdl">wdl</option>
+              </select>
+              <button type="submit"
+                      class="btn btn-link pull-right"
+                      style="padding: 3px 12px!important;"
+                      ng-click="showEditDescriptorType = true"
+                      ng-disabled="editContainerForm.$invalid">
+                <span class="glyphicon glyphicon-floppy-save"></span>Save
+              </button>
+            </div>
           </li>
           <li>
             <strong>Description</strong>:


### PR DESCRIPTION
Other than the default path on tool and workflow, the user can also change the descriptor of the workflow. A dropdown is added alongside the edit button on the Descriptor section in 'Info' tab. 

NOTE: 
- This branch will need to be merged first since there are some changes on the html code for tool and workflow(making the path feature to be visible in general, not just for user to edit). Also to avoid conflict with changes on pull request #50.
- Same thing with previous issue, this issue is related to https://github.com/ga4gh/dockstore/issues/274 and might need to be changed later on if the issue is fixed.