### PR TITLE
coded back missing filter version method

### DIFF
--- a/app/scripts/controllers/workflowfileviewer.js
+++ b/app/scripts/controllers/workflowfileviewer.js
@@ -135,6 +135,18 @@ angular.module('dockstore.ui')
         );
       };
 
+      $scope.filterVersion = function(element) {
+        for(var i=0;i<$scope.successContent.length;i++){
+          if($scope.successContent[i].version === element){
+            return true;
+          } else{
+            if(i===$scope.successContent.length -1){
+              return false;
+            }
+          }
+        }
+      };
+
       $scope.getWorkflowVersions = function() {
         var sortedVersionObjs = $scope.workflowObj.workflowVersions;
         sortedVersionObjs.sort(function(a, b) {


### PR DESCRIPTION
method was accidentally deleted when removing the filter descriptor method from file

https://github.com/ga4gh/dockstore/issues/293 