### PR TITLE
Feature/dockstore 299 dag dropdown

### DIFF
--- a/app/scripts/controllers/workflowdagview.js
+++ b/app/scripts/controllers/workflowdagview.js
@@ -18,6 +18,7 @@ angular.module('dockstore.ui')
       var cy;
       $scope.successContent = [];
       $scope.missingTool = false;
+      $scope.notFound = false;
 
       $scope.getWorkflowVersions = function() {
         var sortedVersionObjs = $scope.workflowObj.workflowVersions;
@@ -97,7 +98,26 @@ angular.module('dockstore.ui')
 
       $scope.refreshDocument = function() {
         $scope.dagJson = $scope.nodesAndEdges($scope.workflowObj.id, $scope.workflowObj.workflowVersions);
+        //$scope.dagJson is a promise returned by the web service from nodesAndEdges function
         if ($scope.dagJson !== null){
+          $scope.dagJson.then(
+          function(s){
+            if(s.nodes.length === 0 && s.edges.length === 0){
+              //DAG has no nodes and edges even though file is valid
+              //some inputs needed from file are missing from Github repo
+              $scope.missingTool = true;
+            }else{
+              //DAG has nodes and edges
+              $scope.missingTool = false;
+            }
+            $scope.notFound = false;
+          },
+          function(e){
+            console.log("dagJSON error");
+            $scope.notFound = true;
+            $scope.missingTool = false;
+          }
+        );
           cy = window.cy = cytoscape({
         	  container: document.getElementById('cy'),
 

--- a/app/scripts/controllers/workflowdagview.js
+++ b/app/scripts/controllers/workflowdagview.js
@@ -65,6 +65,14 @@ angular.module('dockstore.ui')
             });
       };
 
+      $scope.checkVersion = function() {
+        for(var i=0;i<$scope.workflowObj.workflowVersions.length;i++){
+          if($scope.workflowObj.workflowVersions[i].valid){
+            $scope.successContent.push($scope.workflowObj.workflowVersions[i].name);
+          }
+        }
+      };
+
       $scope.filterVersion = function(element) {
         for(var i=0;i<$scope.successContent.length;i++){
           if($scope.successContent[i] === element){

--- a/app/scripts/controllers/workflowdagview.js
+++ b/app/scripts/controllers/workflowdagview.js
@@ -40,20 +40,22 @@ angular.module('dockstore.ui')
       };
 
       $scope.nodesAndEdges = function(workflowId, workflowVersions) {
-      var workflowVersionId;
-      if (workflowVersions.length == 0) {
-        return null;
-      }
-      for (var i = 0; i < workflowVersions.length; i++) {
-        if (workflowVersions[i].name === $scope.selVersionName) {
-          if (workflowVersions[i].valid) {
-            workflowVersionId = workflowVersions[i].id;
-            break;
-          } else {
-            return null;
+        var workflowVersionId;
+        if (workflowVersions.length == 0) {
+          return null;
+        }
+
+        for (var i = 0; i < workflowVersions.length; i++) {
+          if (workflowVersions[i].name === $scope.selVersionName) {
+            if (workflowVersions[i].valid) {
+              workflowVersionId = workflowVersions[i].id;
+              break;
+            } else {
+              return null;
+            }
           }
         }
-      }
+
         return WorkflowService.getWorkflowDag(workflowId, workflowVersionId)
           .then(
             function(dagJson) {
@@ -63,9 +65,11 @@ angular.module('dockstore.ui')
             function(response) {
               return $q.reject(response);
             });
+
       };
 
       $scope.checkVersion = function() {
+        $scope.successContent = [];
         for(var i=0;i<$scope.workflowObj.workflowVersions.length;i++){
           if($scope.workflowObj.workflowVersions[i].valid){
             $scope.successContent.push($scope.workflowObj.workflowVersions[i].name);
@@ -87,7 +91,7 @@ angular.module('dockstore.ui')
 
       $scope.setDocument = function() {
         $scope.workflowVersions = $scope.getWorkflowVersions();
-        $scope.selVersionName = $scope.workflowVersions[0];
+        $scope.selVersionName = $scope.successContent[0];
 
       };
 
@@ -142,6 +146,7 @@ angular.module('dockstore.ui')
               }
             }
           });
+
         } else {
           cy = window.cy = null;
         }

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -34,6 +34,7 @@ angular.module('dockstore.ui')
       };
 
       $scope.openDAG = function() {
+        $scope.$broadcast('checkVersion');
         $scope.$broadcast('refreshFiles');
       };
 

--- a/app/scripts/directives/workflowdagview.js
+++ b/app/scripts/directives/workflowdagview.js
@@ -17,7 +17,10 @@ angular.module('dockstore.ui')
       templateUrl: 'templates/workflowdagview.html',
       link: function postLink(scope, element, attrs) {
         scope.$watch('workflowObj.path', function(newValue, oldValue) {
-          if (newValue) scope.setDocument();
+          if (newValue) {
+            scope.setDocument();
+            scope.checkVersion();
+          }
         });
         scope.$watchGroup(
           ['selVersionName', 'workflowObj.id'],
@@ -27,6 +30,9 @@ angular.module('dockstore.ui')
         scope.$on('refreshFiles', function(event) {
           scope.setDocument();
           scope.refreshDocument();
+        });
+        scope.$on('checkVersion', function(event){
+          scope.checkVersion();
         });
 
       }

--- a/app/scripts/directives/workflowdagview.js
+++ b/app/scripts/directives/workflowdagview.js
@@ -18,8 +18,8 @@ angular.module('dockstore.ui')
       link: function postLink(scope, element, attrs) {
         scope.$watch('workflowObj.path', function(newValue, oldValue) {
           if (newValue) {
-            scope.setDocument();
             scope.checkVersion();
+            scope.setDocument();
           }
         });
         scope.$watchGroup(

--- a/app/templates/workflowdagview.html
+++ b/app/templates/workflowdagview.html
@@ -12,14 +12,18 @@
         </select>
       </div>
     </div>
-    <div class="alert alert-warning" role="alert" ng-show="dagJson === null">
+    <div class="alert alert-warning"
+         role="alert"
+         ng-show="dagJson === null || notFound">
       <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
       A Descriptor associated with this workflow could not be found.
     </div>
-    <!-- <div class="alert alert-warning" role="alert" ng-show="missingtool">
+    <div class="alert alert-warning"
+         role="alert"
+         ng-show="workflowObj.descriptorType === 'cwl' && missingTool">
       <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
-      DAG cannot be created because some tools are missing from repo.
-    </div> -->
-    <div id="cy" ng-show="dagJson !== null"></div>
+      DAG cannot be created because some required tools are missing from Github repo.
+    </div>
+    <div id="cy" ng-show="dagJson !== null && !missingTool"></div>
   </div>
 </div>

--- a/app/templates/workflowdagview.html
+++ b/app/templates/workflowdagview.html
@@ -16,6 +16,10 @@
       <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
       A Descriptor associated with this workflow could not be found.
     </div>
+    <!-- <div class="alert alert-warning" role="alert" ng-show="missingtool">
+      <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
+      DAG cannot be created because some tools are missing from repo.
+    </div> -->
     <div id="cy" ng-show="dagJson !== null"></div>
   </div>
 </div>

--- a/app/templates/workflowdagview.html
+++ b/app/templates/workflowdagview.html
@@ -5,7 +5,7 @@
         <strong>Workflow Version</strong>:
         <select class="ds-version" ng-model="selVersionName">
           <option
-            ng-repeat="version in workflowVersions"
+            ng-repeat="version in workflowVersions | filter: filterVersion "
             value="{{version}}">
             {{version}}
           </option>
@@ -16,10 +16,6 @@
       <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
       A Descriptor associated with this workflow could not be found.
     </div>
-    <!-- <div class="alert alert-warning" role="alert" ng-show="dagJson !== null">
-      <span class="glyphicon glyphicon-warning-sign"></span>&nbsp;
-      DAG cannot be created because this workflow is missing some required tools. 
-    </div> -->
     <div id="cy" ng-show="dagJson !== null"></div>
   </div>
 </div>


### PR DESCRIPTION
Related Issue: https://github.com/ga4gh/dockstore/issues/299 and https://github.com/ga4gh/dockstore/issues/300

Added:
- Workflow version dropdown in 'DAG' tab will only show the versions that have valid descriptor files. In general, it will be the same dropdown as the Version dropdown in 'Descriptor' tab.
- 'No descriptor file found' warning will be shown if no descriptor files are valid, just like in 'Descriptor' tab
- 'Failed to create DAG' warning will be shown if some tools required are not present in the github repo. This warning will be shown only if the descriptor type is cwl. For wdl, if task is not found within the file, the file will be invalid, so it wont even pass the validity check.