### PR TITLE
Feature/dockstore 296 tool tab

### DIFF
--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -39,6 +39,7 @@ angular.module('dockstore.ui')
       };
 
       $scope.getTools = function() {
+        $scope.$broadcast('checkToolVersion');
         $scope.$broadcast('refreshTools');
       };
 

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -38,6 +38,10 @@ angular.module('dockstore.ui')
         $scope.$broadcast('refreshFiles');
       };
 
+      $scope.getTools = function() {
+        $scope.$broadcast('refreshTools');
+      };
+
       $scope.loadWorkflowDetails = function(workflowPath) {
         $scope.setWorkflowDetailsError(null);
         return WorkflowService.getPublishedWorkflowByPath(workflowPath)

--- a/app/scripts/controllers/workfloweditor.js
+++ b/app/scripts/controllers/workfloweditor.js
@@ -208,7 +208,7 @@ angular.module('dockstore.ui')
               return workflows;
             },
             function(response) {
-              $scope.setContainerEditorError(
+              $scope.setWorkflowEditorError(
                 'The webservice encountered an error trying to refresh ' +
                 'containers for User: ' + $scope.userObj.username + '. If the ' +
                 'problem persists after 60 min. has passed, try re-linking ' +

--- a/app/scripts/controllers/workflowtoolsgrid.js
+++ b/app/scripts/controllers/workflowtoolsgrid.js
@@ -19,6 +19,7 @@ angular.module('dockstore.ui')
       $scope.toolJson = null;
       $scope.successContent = [];
       $scope.toolsContent = [];
+      $scope.missingTool = false;
 
       $scope.getWorkflowVersions = function() {
         var sortedVersionObjs = $scope.workflowObj.workflowVersions;
@@ -77,6 +78,15 @@ angular.module('dockstore.ui')
             });
       };
 
+      $scope.checkVersion = function() {
+        $scope.successContent = [];
+        for(var i=0;i<$scope.workflowObj.workflowVersions.length;i++){
+          if($scope.workflowObj.workflowVersions[i].valid){
+            $scope.successContent.push($scope.workflowObj.workflowVersions[i].name);
+          }
+        }
+      };
+
       $scope.filterVersion = function(element) {
         for(var i=0;i<$scope.successContent.length;i++){
           if($scope.successContent[i] === element){
@@ -91,7 +101,7 @@ angular.module('dockstore.ui')
 
       $scope.setDocument = function() {
         $scope.workflowVersions = $scope.getWorkflowVersions();
-        $scope.selVersionName = $scope.workflowVersions[0];
+        $scope.selVersionName = $scope.successContent[0];
 
       };
 
@@ -101,14 +111,20 @@ angular.module('dockstore.ui')
           $scope.toolJson.then(
             function(s){
               $scope.toolsContent = [];
-              for(var i = 0;i<s.length;i++){
-                $scope.toolsContent.push(s[i]);
+              if(s.length === 0){
+                $scope.missingTool = true;
+              }else{
+                for(var i = 0;i<s.length;i++){
+                  $scope.toolsContent.push(s[i]);
+                }
+                $scope.missingTool = false;
               }
+              
               console.log($scope.toolsContent);
             },
             function(e){
               console.log("toolJSON error");
-              
+              $scope.missingTool = true;
             }
           );
         }

--- a/app/scripts/controllers/workflowtoolsgrid.js
+++ b/app/scripts/controllers/workflowtoolsgrid.js
@@ -38,7 +38,6 @@ angular.module('dockstore.ui')
             versions.push(sortedVersionObjs[i].name);
           }
         }
-        console.log("versions: "+versions);
         return versions;
       };
 
@@ -46,10 +45,6 @@ angular.module('dockstore.ui')
         //this function will call the webservice to get 
         //the workflow and tool/task excerpt in form of json
         //and return here as a promise
-
-        console.log("in get table content");
-        console.log("workflowId: "+workflowId);
-        console.log("workflowVersions: "+workflowVersions);
 
         var workflowVersionId;
         if(workflowVersions.length === 0){
@@ -119,8 +114,6 @@ angular.module('dockstore.ui')
                 }
                 $scope.missingTool = false;
               }
-              
-              console.log($scope.toolsContent);
             },
             function(e){
               console.log("toolJSON error");

--- a/app/scripts/directives/workflowtoolsgrid.js
+++ b/app/scripts/directives/workflowtoolsgrid.js
@@ -18,20 +18,23 @@ angular.module('dockstore.ui')
       templateUrl: 'templates/workflowtoolsgrid.html',
       link: function postLink(scope, element, attrs) {
         scope.$watch('workflowObj.path', function(newValue, oldValue) {
-          if (newValue) scope.setDocument();
+          if (newValue) {
+            scope.checkVersion();
+            scope.setDocument();
+          }
         });
         scope.$watchGroup(
           ['selVersionName', 'workflowObj.id'],
           function(newValues, oldValues) {
-              scope.setDocument();
+              scope.refreshDocument();
         });
         scope.$on('refreshTools', function(event) {
           scope.setDocument();
           scope.refreshDocument();
         });
-        // scope.$on('getTools', function(event){
-        //   scope.getTableContent();
-        // });
+        scope.$on('checkToolVersion', function(event){
+          scope.checkVersion();
+        });
       }
     };
   });

--- a/app/scripts/directives/workflowtoolsgrid.js
+++ b/app/scripts/directives/workflowtoolsgrid.js
@@ -25,9 +25,13 @@ angular.module('dockstore.ui')
           function(newValues, oldValues) {
               scope.setDocument();
         });
-        scope.$on('refreshFiles', function(event) {
+        scope.$on('refreshTools', function(event) {
           scope.setDocument();
+          scope.refreshDocument();
         });
+        // scope.$on('getTools', function(event){
+        //   scope.getTableContent();
+        // });
       }
     };
   });

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -220,36 +220,52 @@ angular.module('dockstore.ui')
     };
 
 
-        this.getDescriptorFilePath = function(containerId, tagName, type) {
-          return $q(function(resolve, reject) {
-            $http({
-              method: 'GET',
-              url: WebService.API_URI + '/workflows/' + containerId + '/' + type,
-              params: {
-                tag: tagName
-              }
-            }).then(function(response) {
-              resolve(response.data.path);
-            }, function(response) {
-              reject(response);
-            });
-          });
-        };
+    this.getDescriptorFilePath = function(containerId, tagName, type) {
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'GET',
+          url: WebService.API_URI + '/workflows/' + containerId + '/' + type,
+          params: {
+            tag: tagName
+          }
+        }).then(function(response) {
+          resolve(response.data.path);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
 
-        this.getSecondaryDescriptorFile = function (containerId, tagName, type, secondaryDescriptorPath) {
-          return $q(function (resolve, reject) {
-            $http({
-              method: 'GET',
-              url: WebService.API_URI + '/workflows/' + containerId + '/' + type + '/' + secondaryDescriptorPath,
-              params: {
-                tag: tagName
-              }
-            }).then(function (response) {
-              resolve(response.data.content);
-            }, function (response) {
-              reject(response);
-            });
-          });
-        };
+    this.getSecondaryDescriptorFile = function (containerId, tagName, type, secondaryDescriptorPath) {
+      return $q(function (resolve, reject) {
+        $http({
+          method: 'GET',
+          url: WebService.API_URI + '/workflows/' + containerId + '/' + type + '/' + secondaryDescriptorPath,
+          params: {
+            tag: tagName
+          }
+        }).then(function (response) {
+          resolve(response.data.content);
+        }, function (response) {
+          reject(response);
+        });
+      });
+    };
+
+    this.getTableToolContent = function(workflowId, workflowVersionId){
+      console.log("inside workflow service");
+      console.log(workflowId);
+      console.log(workflowVersionId);
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'GET',
+          url: WebService.API_URI + '/workflows/' + workflowId + '/tools/' + workflowVersionId
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
 
   }]);

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -253,9 +253,6 @@ angular.module('dockstore.ui')
     };
 
     this.getTableToolContent = function(workflowId, workflowVersionId){
-      console.log("inside workflow service");
-      console.log(workflowId);
-      console.log(workflowVersionId);
       return $q(function(resolve, reject) {
         $http({
           method: 'GET',

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -330,7 +330,8 @@
       <!--<uib-tab active="activeTabs[4]" disable="!isWorkflowFull()" style="min-width: 145px !important;">
         <uib-tab-heading>Tools</uib-tab-heading>
         <div workflow-tools-grid
-             workflow-obj="workflowObj">
+            ng-if="workflowObj"
+            workflow-obj="workflowObj">
         </div>
       </uib-tab>-->
       <uib-tab active="activeTabs[5]" disable="!isWorkflowFull()" style="min-width: 145px !important;">

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -134,7 +134,7 @@
           </li>
           <li>
             <strong>{{getRegistry(workflowObj.gitUrl)}}</strong>:
-            <a href="{{getRepoUrl(workflowObj.organization, workflowObj.repository, getRegistry(workflowObj.gitUrl))}}">
+            <a href="{{getRepoUrl(workflowObj.organization, workflowObj.repository, getRegistry(workflowObj.gitUrl))}}" target="_blank">
               {{getRepoUrl(workflowObj.organization, workflowObj.repository, getRegistry(workflowObj.gitUrl))}}
             </a>
           </li>

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -327,13 +327,13 @@
              ng-if="workflowObj">
         </div>
       </uib-tab>
-      <!--<uib-tab active="activeTabs[4]" disable="!isWorkflowFull()" style="min-width: 145px !important;">
-        <uib-tab-heading>Tools</uib-tab-heading>
+      <uib-tab active="activeTabs[4]" disable="!isWorkflowFull()" style="min-width: 145px !important;">
+        <uib-tab-heading ng-click="getTools()">Tools</uib-tab-heading>
         <div workflow-tools-grid
             ng-if="workflowObj"
             workflow-obj="workflowObj">
         </div>
-      </uib-tab>-->
+      </uib-tab>
       <uib-tab active="activeTabs[5]" disable="!isWorkflowFull()" style="min-width: 145px !important;">
         <uib-tab-heading ng-click="openDAG()">DAG</uib-tab-heading>
         <div workflow-dag-view

--- a/app/templates/workflowtoolsgrid.html
+++ b/app/templates/workflowtoolsgrid.html
@@ -20,8 +20,13 @@
             <span class="glyphicon pull-right">
             </span>
         </th>
-        <th>
-          Task/Tool Excerpt
+        <th ng-if="workflowObj.descriptorType === 'cwl'">
+          Tool Excerpt
+            <span class="glyphicon pull-right">
+            </span>
+        </th>
+        <th ng-if="workflowObj.descriptorType === 'wdl'">
+          Task Excerpt
             <span class="glyphicon pull-right">
             </span>
         </th>
@@ -36,10 +41,10 @@
       <!-- Here is where you would need to set up the table content.  See workflowdagview for help on calling
        dag json for the given workflow and version.  Then write a function in the workflowtoolsgrid.js controller
        to store to an array that you will ng-repeat over-->
-      <!--<tr ng-repeat="" ng-hide="">-->
-        <!--<td>-->
-        <!--</td>-->
-      <!--</tr>-->
+      <!--<tr ng-repeat="" ng-hide="">
+        <td>
+        </td>
+      </tr>-->
       </tbody>
     </table>
   </div>

--- a/app/templates/workflowtoolsgrid.html
+++ b/app/templates/workflowtoolsgrid.html
@@ -51,9 +51,10 @@
         </td>
         <td>
           <strong>run</strong>:&nbsp{{tool.file}}<br>
-          <strong>class</strong>:&nbsp{{tool.class}}<br>
           <strong>docker</strong>:&nbsp{{tool.docker}}<br>
-          <strong>link</strong>:&nbsp<a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
+          <strong>link</strong>:&nbsp
+            <a href="{{tool.link}}" target="_blank" ng-if="tool.link !== 'Not Specified'">{{tool.link}}</a>
+            <span ng-if="tool.link === 'Not Specified'">Not Specified</span>
         </td>
       </tr>
       <tr
@@ -64,7 +65,9 @@
         </td>
         <td>
           <strong>docker</strong>:&nbsp{{tool.docker}}<br>
-          <strong>link</strong>:&nbsp<a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
+          <strong>link</strong>:&nbsp
+            <a href="{{tool.link}}" target="_blank" ng-if="tool.link !== 'Not Specified'">{{tool.link}}</a>
+            <span ng-if="tool.link === 'Not Specified'">Not Specified</span>
         </td>
       </tr>
       </tbody>

--- a/app/templates/workflowtoolsgrid.html
+++ b/app/templates/workflowtoolsgrid.html
@@ -40,7 +40,7 @@
       </tr>
       <tr ng-show="toolJson !== null && missingTool">
         <td colspan="7">
-          <div class="text-center">Tools associated with this workflow cannot be found</div>
+          <div class="text-center">Some tools associated with this workflow are missing from Github repo.</div>
         </td>
       </tr>
       <tr

--- a/app/templates/workflowtoolsgrid.html
+++ b/app/templates/workflowtoolsgrid.html
@@ -33,7 +33,7 @@
       </tr>
       </thead>
       <tbody>
-      <tr>
+      <tr ng-show="toolJson === null">
         <td colspan="7">
           <div class="text-center">No Records Found</div>
         </td>
@@ -41,10 +41,20 @@
       <!-- Here is where you would need to set up the table content.  See workflowdagview for help on calling
        dag json for the given workflow and version.  Then write a function in the workflowtoolsgrid.js controller
        to store to an array that you will ng-repeat over-->
-      <!--<tr ng-repeat="" ng-hide="">
+      <tr
+        ng-repeat="tool in toolsContent" 
+        ng-show="toolJson !== null">
         <td>
+          <strong>tool&nbspID</strong>:&nbsp{{tool.id}}<br>
         </td>
-      </tr>-->
+        <td>
+          <strong>run</strong>:&nbsp{{tool.file}}<br>
+          <strong>class</strong>:&nbsp{{tool.class}}<br>
+          <strong>docker</strong>:&nbsp{{tool.docker}}<br>
+          <strong>link</strong>:&nbsp
+            <a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
+        </td>
+      </tr>
       </tbody>
     </table>
   </div>

--- a/app/templates/workflowtoolsgrid.html
+++ b/app/templates/workflowtoolsgrid.html
@@ -5,7 +5,7 @@
         <strong>Workflow Version</strong>:
         <select class="ds-version" ng-model="selVersionName">
           <option
-            ng-repeat="version in workflowVersions"
+            ng-repeat="version in workflowVersions | filter: filterVersion"
             value="{{version}}">
             {{version}}
           </option>
@@ -38,12 +38,14 @@
           <div class="text-center">No Records Found</div>
         </td>
       </tr>
-      <!-- Here is where you would need to set up the table content.  See workflowdagview for help on calling
-       dag json for the given workflow and version.  Then write a function in the workflowtoolsgrid.js controller
-       to store to an array that you will ng-repeat over-->
+      <tr ng-show="toolJson !== null && missingTool">
+        <td colspan="7">
+          <div class="text-center">Tools associated with this workflow cannot be found</div>
+        </td>
+      </tr>
       <tr
         ng-repeat="tool in toolsContent" 
-        ng-show="toolJson !== null">
+        ng-if="toolJson !== null && workflowObj.descriptorType === 'cwl'">
         <td>
           <strong>tool&nbspID</strong>:&nbsp{{tool.id}}<br>
         </td>
@@ -51,8 +53,18 @@
           <strong>run</strong>:&nbsp{{tool.file}}<br>
           <strong>class</strong>:&nbsp{{tool.class}}<br>
           <strong>docker</strong>:&nbsp{{tool.docker}}<br>
-          <strong>link</strong>:&nbsp
-            <a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
+          <strong>link</strong>:&nbsp<a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
+        </td>
+      </tr>
+      <tr
+        ng-repeat="tool in toolsContent" 
+        ng-if="toolJson !== null && workflowObj.descriptorType === 'wdl'">
+        <td>
+          <strong>task&nbspID</strong>:&nbsp{{tool.id}}<br>
+        </td>
+        <td>
+          <strong>docker</strong>:&nbsp{{tool.docker}}<br>
+          <strong>link</strong>:&nbsp<a href="{{tool.link}}" target="_blank">{{tool.link}}</a>
         </td>
       </tr>
       </tbody>


### PR DESCRIPTION
Related issue: https://github.com/ga4gh/dockstore/issues/296
Related pull request: https://github.com/ga4gh/dockstore/pull/315

- 'Tools' tab is implemented and added to the GUI. Inside this tab, there will be tools that are required to run the workflow. In general each tool will be the same as each node in DAG. 
- Information provided in 'Tools' tab for 
     * CWL: ID, filename, docker, docker link
     * WDL: ID, docker, docker link
- If the tool does not have any docker requirement specified, it will be, by default, changed to the docker requirement of the workflow. If the workflow also does not specify any docker requirement, then the 'docker' and 'link' field will have 'Not Specified'
- If required tools are missing from Github Repo, there will be warninng(similar to DAG tab) : "Some tools associated with this workflow are missing from Github repo."
- Workflow version dropdown is the same as in Descriptor and DAG tab, version with invalid/not found descriptor file will not be included