### PR TITLE
Feature/dockstore 284 streamline path descriptor

### DIFF
--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -211,6 +211,29 @@ angular.module('dockstore.ui')
           );
       };
 
+      $scope.updateWorkflowPathVersion = function(workflowId, path){
+        return WorkflowService.updateWorkflowPathVersion(workflowId, path, $scope.workflowObj.workflowName, $scope.workflowObj.descriptorType, 
+          $scope.workflowObj.path, $scope.workflowObj.gitUrl)
+          .then(
+            function(workflowObj){
+              $scope.workflowObj.workflow_path = workflowObj.workflow_path;
+              $scope.updateWorkflowObj();
+              return workflowObj;
+            },
+            function(response) {
+              $scope.setWorkflowDetailsError(
+                'The webservice encountered an error trying to modify default path ' +
+                'for this workflow, please ensure that the path is valid, ' +
+                'properly-formatted and does not contain prohibited ' +
+                'characters of words.',
+                '[HTTP ' + response.status + '] ' + response.statusText + ': ' +
+                response.data
+              );
+              return $q.reject(response);
+            }
+          );
+      };
+
       $scope.setWorkflowLabels = function(workflowId, labels) {
         $scope.setWorkflowDetailsError(null);
         return WorkflowService.setWorkflowLabels(workflowId, labels)
@@ -338,6 +361,10 @@ angular.module('dockstore.ui')
           $scope.setDefaultWorkflowPath($scope.workflowObj.id, $scope.workflowObj.workflow_path)
             .then(function(workflowObj) {
               $scope.labelsEditMode = false;
+            });
+          $scope.updateWorkflowPathVersion($scope.workflowObj.id, $scope.workflowObj.workflow_path)
+            .then(function(workflowObj) {
+              $scope.labelsEditMode = false;
               $scope.refreshWorkflow($scope.workflowObj.id,0);
             });
         }
@@ -351,7 +378,10 @@ angular.module('dockstore.ui')
         $scope.setDescriptorType($scope.workflowObj.id)
           .then(
             function(workflowObj){
-              $scope.refreshWorkflow($scope.workflowObj.id,0);
+              $scope.updateWorkflowPathVersion($scope.workflowObj.id, $scope.workflowObj.workflow_path)
+              .then(function(workflowObj) {
+                $scope.refreshWorkflow($scope.workflowObj.id,0);
+              });
             });
       };
 

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -24,6 +24,9 @@ angular.module('dockstore.ui')
       $scope.invalidClass = false;
       $scope.showEditWorkflowPath = true;
       $scope.showEditDescriptorType = true;
+      $scope.pathExtensions = ['cwl','wdl','yml','yaml'];
+      $scope.extensionWarning = false;
+
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
         for (var i = 0; i < 3; i++) $scope.activeTabs.push(false);
@@ -324,11 +327,14 @@ angular.module('dockstore.ui')
 
       $scope.submitWorkflowPathEdits = function(){
         if($scope.workflowObj.workflow_path !== 'undefined'){
-          $scope.setDefaultWorkflowPath($scope.workflowObj.id,
-            $scope.workflowObj.workflow_path)
-          .then(function(workflowObj) {
-            $scope.labelsEditMode = false;
-          });
+          //get the extension of the workflow path and check if it's within the extensions array
+          $scope.checkExtension($scope.workflowObj.workflow_path);
+
+          //change on the webservice
+          $scope.setDefaultWorkflowPath($scope.workflowObj.id, $scope.workflowObj.workflow_path)
+            .then(function(workflowObj) {
+              $scope.labelsEditMode = false;
+            });
         }
       };
 
@@ -353,6 +359,28 @@ angular.module('dockstore.ui')
             .then(function(workflowObj) {
               $scope.labelsEditMode = false;
             });
+        }
+      };
+
+      $scope.checkExtension = function(path){
+        var indexPeriod = path.indexOf('.');
+        var ext = "";
+        if(indexPeriod !== -1){
+          ext = path.substring(indexPeriod+1,path.length);
+          if($scope.pathExtensions.indexOf(ext) !== -1){
+            //extension is one of [cwl,wdl,yaml,yml]
+            if(ext !== $scope.workflowObj.descriptorType){
+              if(ext !== 'wdl'){
+                $scope.workflowObj.descriptorType = 'cwl';
+              }else{
+                $scope.workflowObj.descriptorType = 'wdl';
+              }
+            }
+          }else{
+            $scope.extensionWarning = true;
+          }
+        }else{
+          $scope.extensionWarning = true;
         }
       };
 

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -333,6 +333,7 @@ angular.module('dockstore.ui')
           $scope.setDefaultWorkflowPath($scope.workflowObj.id, $scope.workflowObj.workflow_path)
             .then(function(workflowObj) {
               $scope.labelsEditMode = false;
+              $scope.refreshWorkflow($scope.workflowObj.id,0);
             });
         }
       };

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -346,7 +346,7 @@ angular.module('dockstore.ui')
         $scope.setDescriptorType($scope.workflowObj.id)
           .then(
             function(workflowObj){
-              console.log("success submit descriptor edit");
+              $scope.refreshWorkflow($scope.workflowObj.id,0);
             });
       };
 

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -26,9 +26,12 @@ angular.module('dockstore.ui')
       $scope.showEditDescriptorType = true;
       $scope.pathExtensions = ['cwl','wdl','yml','yaml'];
 
+      //there are 6 tabs, and only 1 tab can be active
+      //so there are 5 tabs that are not active
+      var notActiveTabs = 5;
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
-        for (var i = 0; i < 3; i++) $scope.activeTabs.push(false);
+        for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs.push(false);
       }
 
       $scope.checkPage = function(){
@@ -344,7 +347,7 @@ angular.module('dockstore.ui')
        };
 
       $scope.selectLabelTab = function() {
-       for (var i = 0; i < 4; i++) $scope.activeTabs[i] = false;
+       for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs[i] = false;
        $scope.activeTabs[1] = true;
       };
 

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -360,7 +360,6 @@ angular.module('dockstore.ui')
           //change on the webservice
           $scope.setDefaultWorkflowPath($scope.workflowObj.id, $scope.workflowObj.workflow_path)
             .then(function(workflowObj) {
-              $scope.labelsEditMode = false;
               $scope.updateWorkflowPathVersion($scope.workflowObj.id, $scope.workflowObj.workflow_path)
                 .then(function(workflowObj) {
                   $scope.labelsEditMode = false;

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -361,11 +361,11 @@ angular.module('dockstore.ui')
           $scope.setDefaultWorkflowPath($scope.workflowObj.id, $scope.workflowObj.workflow_path)
             .then(function(workflowObj) {
               $scope.labelsEditMode = false;
-            });
-          $scope.updateWorkflowPathVersion($scope.workflowObj.id, $scope.workflowObj.workflow_path)
-            .then(function(workflowObj) {
-              $scope.labelsEditMode = false;
-              $scope.refreshWorkflow($scope.workflowObj.id,0);
+              $scope.updateWorkflowPathVersion($scope.workflowObj.id, $scope.workflowObj.workflow_path)
+                .then(function(workflowObj) {
+                  $scope.labelsEditMode = false;
+                  $scope.refreshWorkflow($scope.workflowObj.id,0);
+                });
             });
         }
       };

--- a/app/scripts/controllers/workflowdetails.js
+++ b/app/scripts/controllers/workflowdetails.js
@@ -422,14 +422,6 @@ angular.module('dockstore.ui')
         }else if(path === ""){
           //path is empty, should by default put "/Dockstore."+descriptorType
            $scope.workflowObj.workflow_path = '/Dockstore.'+$scope.workflowObj.descriptorType;
-        }else{
-          //extension is not in extension array and path is not empty
-          var extLowerCase = ext.toLowerCase();
-          if($scope.pathExtensions.indexOf(extLowerCase) !== -1){
-            //although this might be the only case, just making sure that
-            //extension is in upper case, but it's actually in the extension array when changed to lowerCase
-            $scope.changeExt(path,"");
-          }
         }
       };
 

--- a/app/scripts/controllers/workfloweditor.js
+++ b/app/scripts/controllers/workfloweditor.js
@@ -23,7 +23,10 @@ angular.module('dockstore.ui')
 
       $scope.userObj = UserService.getUserObj();
       $scope.activeTabs = [true];
-      for (var i = 0; i < 4; i++) $scope.activeTabs.push(false);
+      //there are 6 tabs, and only 1 tab can be active
+      //so there are 5 tabs that are not active
+      var notActiveTabs = 5;
+      for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs.push(false);
 
       $scope.listUserWorkflows = function(userId) {
         $scope.setWorkflowEditorError(null);

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -150,7 +150,27 @@ angular.module('dockstore.ui')
       });
     };
 
-  this.getWorkflowDag = function(workflowId, workflowVersionId) {
+    this.updateWorkflowPathVersion = function(workflowId, workflowpath, workflowname, descType,path, giturl) {
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'PUT',
+          url: WebService.API_URI + '/workflows/' + workflowId +'/resetVersionPaths',
+          data: {
+            workflow_path: workflowpath,
+            workflowName: workflowname,
+            descriptorType: descType,
+            path: path,
+            gitUrl: giturl
+          }
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
+
+    this.getWorkflowDag = function(workflowId, workflowVersionId) {
       return $q(function(resolve, reject) {
         $http({
           method: 'GET',

--- a/app/templates/validation/workflows/descriptorpath.html
+++ b/app/templates/validation/workflows/descriptorpath.html
@@ -5,7 +5,7 @@
   Workflow Path is too short. (Min. 3 characters.)
 </p>
 <p ng-message="maxlength">
-  Workflow Path is too long. (Max 128 characters.)
+  Workflow Path is too long. (Max 256 characters.)
 </p>
 <p ng-message="pattern">
   Invalid Workflow Path format. Workflow Path must begin with '/' and end with end with '*.cwl', '*.yml', '*.yaml', or'*.wdl'.

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -226,16 +226,14 @@
           <!-- when in edit mode and Edit button for descriptor is clicked-->
             <div ng-show="editMode && !showEditDescriptorType">
             <Strong>Descriptor Type</Strong>:
-              <select
-                ng-model="workflowObj.descriptorType"
-                ng-change="submitDescriptorEdit()">
+              <select ng-model="workflowObj.descriptorType">
               <option value="cwl">cwl</option>
               <option value="wdl">wdl</option>
               </select>
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
-                      ng-click="showEditDescriptorType = true"
+                      ng-click="showEditDescriptorType = true;submitDescriptorEdit()"
                       ng-disabled="editContainerForm.$invalid">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -169,14 +169,20 @@
             </div>
 
             <!-- for when it's edit mode and Edit button clicked-->
-            <form name="editContainerForm"
+            <form name="editWorkflowPath"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditWorkflowPath"
                   ng-submit="submitWorkflowPathEdits()">
+              <div class="form-error-messages"
+                  ng-messages="editWorkflowPath.contDescPath.$error"
+                  ng-if="editWorkflowPath.contDescPath.$touched">
+                <div ng-messages-include="templates/validation/workflows/descriptorpath.html">
+                </div>
+              </div>
               <button type="submit"
                       class="btn btn-link pull-right"
                       ng-click="showEditWorkflowPath = true"
-                      ng-disabled="editContainerForm.$invalid">
+                      ng-disabled="editWorkflowPath.contDescPath.$invalid || refreshingWorkflow">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
               <div ng-show="!showEditWorkflowPath">
@@ -191,13 +197,6 @@
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockstore.cwl" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/descriptorpath.html">
-                    </div>
-                  </div>
                 </div>
               </div>
             </form>
@@ -233,8 +232,7 @@
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
-                      ng-click="showEditDescriptorType = true;submitDescriptorEdit()"
-                      ng-disabled="editContainerForm.$invalid">
+                      ng-click="showEditDescriptorType = true;submitDescriptorEdit()">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
             </div>


### PR DESCRIPTION
Related issue: https://github.com/ga4gh/dockstore/issues/284 
Related pull request: https://github.com/ga4gh/dockstore/pull/327

- If the default workflow path in "Info" tab is changed, the descriptor type dropdown below it will be changed automatically. 
 - Workflow path with file extension of cwl,yml,yaml will change the dropdown to cwl
 - Workflow path with file extension of wdl will change the dropdown to wdl
- If the descriptor type dropdown is changed, the workflow path file extension will also be changed. cwl will be changed to *.cwl, and wdl to *.wdl. It is not possible to change the workflow path if it's already yaml/yml from the dropdown because there are only two descriptor types available, and to change the file extension to yaml/yml will automatically change the dropdown to cwl.
- Changes on the default workflow path will change all the workflow path of the versions available in the workflow. However, changing the workflow path on each version (through 'Version' tab), will not change the default workflow path(in 'Info' tab). Everytime the workflow path is changed, the UI will call 'refreshWorkflow' which will work the same as hitting 'Refresh' button, or else the information wont be updated in the UI  --> These changes are on the webservice side, but it gets refreshed on the UI side
- If the default workflow path is edited to blank, it will be changed to '/Dockstore.'+descriptor type(as the extension)

NOTE: there is a validation check in the form, it is impossible for the user to hit Save button if there is no extension or if the file extension is not one of cwl,wdl,yaml,yml. No warning is implemented because of this validation check feature.