### PR TITLE
Feature/dockstore 328 streamline tool path

### DIFF
--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -393,10 +393,15 @@ angular.module('dockstore.ui')
         var wdlpath = $scope.containerObj.default_wdl_path;
         var dfpath = $scope.containerObj.default_dockerfile_path;
 
+
         if(type === 'cwl' && cwlpath === ''){
+          if(wdlpath === ''){
             cwlpath = '/Dockstore.cwl';
+          }
         } else if(type === 'wdl' && wdlpath === ''){
+          if(cwlpath === ''){
             wdlpath = '/Dockstore.wdl';
+          }
         } else if(type === 'dockerfile' && dfpath === ''){
             dfpath = '/Dockerfile';
         }

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -389,6 +389,24 @@ angular.module('dockstore.ui')
         var wdlpath = $scope.containerObj.default_wdl_path;
         var dfpath = $scope.containerObj.default_dockerfile_path;
 
+        if(type === 'cwl'){
+          if(cwlpath !== ''){
+            cwlpath = $scope.lowercaseExtension(cwlpath);
+          } else{
+            cwlpath = '/Dockstore.cwl';
+          }
+        } else if(type === 'wdl'){
+          if(cwlpath !== ''){
+            wdlpath = $scope.lowercaseExtension(wdlpath);
+          } else{
+            wdlpath = '/Dockstore.wdl';
+          }
+        } else{
+          if(dfpath === ''){
+            dfpath = '/Dockerfile';
+          }
+        }
+
         if($scope.containerObj.default_cwl_path !== 'undefined' || $scope.containerObj.default_wdl_path !== 'undefined' 
             || $scope.containerObj.default_dockerfile_path !== 'undefined'){
           $scope.setDefaultToolPath($scope.containerObj.id,
@@ -402,6 +420,15 @@ angular.module('dockstore.ui')
           });
         }
 
+      };
+
+      $scope.lowercaseExtension = function(path) {
+        var indexPeriod = path.indexOf('.');
+        //if indexPeriod = -1, it will fail the form validation
+        //so will never have indexPeriod = -1
+        var extension = path.substring(indexPeriod,path.length);
+        var stringNoExt = path.substring(0,indexPeriod);
+        return stringNoExt+extension.toLowerCase();
       };
 
       $scope.submitContainerEdits = function() {

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -26,7 +26,6 @@ angular.module('dockstore.ui')
       $scope.showEditCWL = true;
       $scope.showEditWDL = true;
       $scope.showEditDockerfile = true;
-      $scope.cwlPathExtension = ['cwl','yaml','yml'];
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
         for (var i = 0; i < 4; i++) $scope.activeTabs.push(false);
@@ -390,14 +389,6 @@ angular.module('dockstore.ui')
         var wdlpath = $scope.containerObj.default_wdl_path;
         var dfpath = $scope.containerObj.default_dockerfile_path;
 
-        if(type === 'cwl'){
-          $scope.checkExtension(cwlpath);
-        } else if(type === 'wdl'){
-          $scope.checkExtension(wdlpath);
-        } else if(type === 'dockerfile'){
-          $scope.checkExtension(dfpath);
-        }
-
         if($scope.containerObj.default_cwl_path !== 'undefined' || $scope.containerObj.default_wdl_path !== 'undefined' 
             || $scope.containerObj.default_dockerfile_path !== 'undefined'){
           $scope.setDefaultToolPath($scope.containerObj.id,
@@ -411,10 +402,6 @@ angular.module('dockstore.ui')
           });
         }
 
-      };
-
-      $scope.checkExtension = function(type) {
-        //will check extension for uppercase and invalid ones
       };
 
       $scope.submitContainerEdits = function() {

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -389,22 +389,12 @@ angular.module('dockstore.ui')
         var wdlpath = $scope.containerObj.default_wdl_path;
         var dfpath = $scope.containerObj.default_dockerfile_path;
 
-        if(type === 'cwl'){
-          if(cwlpath !== ''){
-            cwlpath = $scope.lowercaseExtension(cwlpath);
-          } else{
+        if(type === 'cwl' && cwlpath === ''){
             cwlpath = '/Dockstore.cwl';
-          }
-        } else if(type === 'wdl'){
-          if(cwlpath !== ''){
-            wdlpath = $scope.lowercaseExtension(wdlpath);
-          } else{
+        } else if(type === 'wdl' && wdlpath === ''){
             wdlpath = '/Dockstore.wdl';
-          }
-        } else{
-          if(dfpath === ''){
+        } else if(type === 'dockerfile' && dfpath === ''){
             dfpath = '/Dockerfile';
-          }
         }
 
         if($scope.containerObj.default_cwl_path !== 'undefined' || $scope.containerObj.default_wdl_path !== 'undefined' 
@@ -420,15 +410,6 @@ angular.module('dockstore.ui')
           });
         }
 
-      };
-
-      $scope.lowercaseExtension = function(path) {
-        var indexPeriod = path.indexOf('.');
-        //if indexPeriod = -1, it will fail the form validation
-        //so will never have indexPeriod = -1
-        var extension = path.substring(indexPeriod,path.length);
-        var stringNoExt = path.substring(0,indexPeriod);
-        return stringNoExt+extension.toLowerCase();
       };
 
       $scope.submitContainerEdits = function() {

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -176,67 +176,20 @@ angular.module('dockstore.ui')
         }
       };
 
-      $scope.setDefaultCWLPath = function(containerId, cwlpath){
-        var wdlpath = $scope.containerObj.default_wdl_path;
-        var dfpath = $scope.containerObj.default_dockerfile_path;
+      $scope.setDefaultToolPath = function(containerId, cwlpath, wdlpath, dfpath){
         var toolname = $scope.containerToolname;
         var giturl = $scope.containerObj.gitUrl;
-        return ContainerService.setDefaultCWLPath(containerId, cwlpath,wdlpath,dfpath,toolname,giturl)
-          .then(
-            function(containerObj){
-              $scope.containerObj.default_cwl_path = containerObj.default_cwl_path;
-              $scope.updateContainerObj();
-              return containerObj;
-            },
-            function(response) {
-              $scope.setContainerDetailsError(
-                'The webservice encountered an error trying to modify default path ' +
-                'for this container, please ensure that the path is valid, ' +
-                'properly-formatted and does not contain prohibited ' +
-                'characters of words.',
-                '[HTTP ' + response.status + '] ' + response.statusText + ': ' +
-                response.data
-              );
-              return $q.reject(response);
-            }
-          );
-      };
 
-      $scope.setDefaultWDLPath = function(containerId, wdlpath){
-        var cwlpath = $scope.containerObj.default_cwl_path;
-        var dfpath = $scope.containerObj.default_dockerfile_path;
-        var toolname = $scope.containerToolname;
-        var giturl = $scope.containerObj.gitUrl;
-        return ContainerService.setDefaultWDLPath(containerId, cwlpath,wdlpath,dfpath,toolname,giturl)
+        return ContainerService.setDefaultToolPath(containerId, cwlpath, wdlpath, dfpath,toolname, giturl)
           .then(
             function(containerObj){
-              $scope.containerObj.default_wdl_path = containerObj.default_wdl_path;
-              $scope.updateContainerObj();
-              return containerObj;
-            },
-            function(response) {
-              $scope.setContainerDetailsError(
-                'The webservice encountered an error trying to modify default path ' +
-                'for this container, please ensure that the path is valid, ' +
-                'properly-formatted and does not contain prohibited ' +
-                'characters of words.',
-                '[HTTP ' + response.status + '] ' + response.statusText + ': ' +
-                response.data
-              );
-              return $q.reject(response);
-            }
-          );
-      };
-
-      $scope.setDefaultDockerfilePath = function(containerId, dfpath){
-        var cwlpath = $scope.containerObj.default_cwl_path;
-        var wdlpath = $scope.containerObj.default_wdl_path;
-        var toolname = $scope.containerToolname;
-        var giturl = $scope.containerObj.gitUrl;
-        return ContainerService.setDefaultDockerfilePath(containerId, cwlpath,wdlpath,dfpath,toolname,giturl)
-          .then(
-            function(containerObj){
-              $scope.containerObj.default_dockerfile_path = containerObj.default_dockerfile_path;
+              if($scope.containerObj.default_cwl_path !== containerObj.default_cwl_path){
+                $scope.containerObj.default_cwl_path = containerObj.default_cwl_path;
+              } else if($scope.containerObj.default_wdl_path !== containerObj.default_wdl_path){
+                $scope.containerObj.default_wdl_path = containerObj.default_wdl_path;
+              } else if($scope.containerObj.default_dockerfile_path !== containerObj.default_dockerfile_path){
+                $scope.containerObj.default_dockerfile_path = containerObj.default_dockerfile_path;
+              }
               $scope.updateContainerObj();
               return containerObj;
             },
@@ -382,10 +335,10 @@ angular.module('dockstore.ui')
         }
       };
 
-       $scope.moveToStart = function(element) {
-            $('#label-button-holder').insertBefore($('#' + element));
+      $scope.moveToStart = function(element) {
+        $('#label-button-holder').insertBefore($('#' + element));
 
-            };
+      };
 
       $scope.selectLabelTab = function() {
        for (var i = 0; i < 4; i++) $scope.activeTabs[i] = false;
@@ -400,32 +353,20 @@ angular.module('dockstore.ui')
         return FrmttSrvc.getFilteredDockerPullCmd(path);
       };
 
-      $scope.submitDescriptorEdits = function(type){
-        if (type === 'cwl') {
-          if($scope.containerObj.default_cwl_path !== 'undefined'){
-            $scope.setDefaultCWLPath($scope.containerObj.id,
-              $scope.containerObj.default_cwl_path)
-            .then(function(containerObj) {
-              $scope.labelsEditMode = false;
-            });
-          }
-        } else if(type === 'wdl'){
-          if($scope.containerObj.default_wdl_path !== 'undefined'){
-            $scope.setDefaultWDLPath($scope.containerObj.id,
-              $scope.containerObj.default_wdl_path)
-            .then(function(containerObj) {
-              $scope.labelsEditMode = false;
-            });
-          }
-        } else if(type === 'dockerfile'){
-          if($scope.containerObj.default_dockerfile_path !== 'undefined'){
-            $scope.setDefaultDockerfilePath($scope.containerObj.id,
-              $scope.containerObj.default_dockerfile_path)
-            .then(function(containerObj) {
-              $scope.labelsEditMode = false;
-            });
-          }
+      $scope.submitDescriptorEdits = function(){
+        var cwlpath = $scope.containerObj.default_cwl_path;
+        var wdlpath = $scope.containerObj.default_wdl_path;
+        var dfpath = $scope.containerObj.default_dockerfile_path;
+
+        if($scope.containerObj.default_cwl_path !== 'undefined' || $scope.containerObj.default_wdl_path !== 'undefined' 
+            || $scope.containerObj.default_dockerfile_path !== 'undefined'){
+          $scope.setDefaultToolPath($scope.containerObj.id,
+            cwlpath, wdlpath, dfpath)
+          .then(function(containerObj) {
+            $scope.labelsEditMode = false;
+          });
         }
+
       };
 
       $scope.submitContainerEdits = function() {

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -26,9 +26,13 @@ angular.module('dockstore.ui')
       $scope.showEditCWL = true;
       $scope.showEditWDL = true;
       $scope.showEditDockerfile = true;
+      //There are 5 tabs, and only 1 can be active
+      // so there are 4 other tabs that are not active
+      var notActiveTabs = 4;
+
       if (!$scope.activeTabs) {
         $scope.activeTabs = [true];
-        for (var i = 0; i < 4; i++) $scope.activeTabs.push(false);
+        for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs.push(false);
       }
 
       $scope.checkPage = function(){
@@ -372,7 +376,7 @@ angular.module('dockstore.ui')
       };
 
       $scope.selectLabelTab = function() {
-       for (var i = 0; i < 4; i++) $scope.activeTabs[i] = false;
+       for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs[i] = false;
        $scope.activeTabs[1] = true;
       };
 

--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -187,12 +187,12 @@ angular.module('dockstore.ui')
         return ContainerService.updateToolPathTag(containerId, cwlpath, wdlpath, dfpath,toolname, giturl)
           .then(
             function(containerObj){
-              if($scope.containerObj.default_cwl_path !== containerObj[0].cwl_path){
-                $scope.containerObj.default_cwl_path = containerObj[0].cwl_path;
-              } else if($scope.containerObj.default_wdl_path !== containerObj[0].wdl_path){
-                $scope.containerObj.default_wdl_path = containerObj[0].wdl_path;
-              } else if($scope.containerObj.default_dockerfile_path !== containerObj[0].dockerfile_path){
-                $scope.containerObj.default_dockerfile_path = containerObj[0].dockerfile_path;
+              if($scope.containerObj.default_cwl_path !== containerObj.default_cwl_path){
+                $scope.containerObj.default_cwl_path = containerObj.default_cwl_path;
+              } else if($scope.containerObj.default_wdl_path !== containerObj.default_wdl_path){
+                $scope.containerObj.default_wdl_path = containerObj.default_wdl_path;
+              } else if($scope.containerObj.default_dockerfile_path !== containerObj.default_dockerfile_path){
+                $scope.containerObj.default_dockerfile_path = containerObj.default_dockerfile_path;
               }
               $scope.updateContainerObj();
               return containerObj;
@@ -218,6 +218,7 @@ angular.module('dockstore.ui')
         return ContainerService.setDefaultToolPath(containerId, cwlpath, wdlpath, dfpath,toolname, giturl)
           .then(
             function(containerObj){
+
               if($scope.containerObj.default_cwl_path !== containerObj.default_cwl_path){
                 $scope.containerObj.default_cwl_path = containerObj.default_cwl_path;
               } else if($scope.containerObj.default_wdl_path !== containerObj.default_wdl_path){

--- a/app/scripts/controllers/containereditor.js
+++ b/app/scripts/controllers/containereditor.js
@@ -23,7 +23,10 @@ angular.module('dockstore.ui')
 
       $scope.userObj = UserService.getUserObj();
       $scope.activeTabs = [true];
-      for (var i = 0; i < 4; i++) $scope.activeTabs.push(false);
+      //there are 5 tabs, and only 1 tab can be active
+      //so there are 4 tabs that are not active
+      var notActiveTabs = 4;
+      for (var i = 0; i < notActiveTabs; i++) $scope.activeTabs.push(false);
 
       $scope.listUserContainers = function(userId) {
         $scope.setContainerEditorError(null);

--- a/app/scripts/services/containerservice.js
+++ b/app/scripts/services/containerservice.js
@@ -240,48 +240,7 @@ angular.module('dockstore.ui')
     };
 
     // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
-    this.setDefaultCWLPath = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
-      return $q(function(resolve, reject) {
-        $http({
-          method: 'PUT',
-          url: WebService.API_URI + '/containers/' + containerId,
-          data: {
-            default_cwl_path: cwlPath,
-            default_wdl_path: wdlPath,
-            default_dockerfile_path: dfPath,
-            toolname: toolname,
-            gitUrl: giturl
-          }
-        }).then(function(response) {
-          resolve(response.data);
-        }, function(response) {
-          reject(response);
-        });
-      });
-    };
-
-    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
-    this.setDefaultWDLPath = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
-      return $q(function(resolve, reject) {
-        $http({
-          method: 'PUT',
-          url: WebService.API_URI + '/containers/' + containerId,
-          data: {
-            default_cwl_path: cwlPath,
-            default_wdl_path: wdlPath,
-            default_dockerfile_path: dfPath,
-            toolname: toolname,
-            gitUrl: giturl
-          }
-        }).then(function(response) {
-          resolve(response.data);
-        }, function(response) {
-          reject(response);
-        });
-      });
-    };
-
-    this.setDefaultDockerfilePath = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
+    this.setDefaultToolPath = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
       return $q(function(resolve, reject) {
         $http({
           method: 'PUT',

--- a/app/scripts/services/containerservice.js
+++ b/app/scripts/services/containerservice.js
@@ -260,6 +260,26 @@ angular.module('dockstore.ui')
       });
     };
 
+    this.updateToolPathTag = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'PUT',
+          url: WebService.API_URI + '/containers/' + containerId + '/updateTagPaths',
+          data: {
+            default_cwl_path: cwlPath,
+            default_wdl_path: wdlPath,
+            default_dockerfile_path: dfPath,
+            toolname: toolname,
+            gitUrl: giturl
+          }
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
+
     this.getDockerFile = function(containerId, tagName) {
       return $q(function(resolve, reject) {
         $http({

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -208,7 +208,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditDockerfile"
-                  ng-submit="submitDescriptorEdits()">
+                  ng-submit="submitDescriptorEdits('dockerfile')">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
@@ -260,7 +260,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditCWL"
-                  ng-submit="submitDescriptorEdits()">
+                  ng-submit="submitDescriptorEdits('cwl')">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
@@ -276,7 +276,7 @@
                       class="input-default form-control"
                       name="contDescPath"
                       ng-model="containerObj.default_cwl_path"
-                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.cwl$/i"
+                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|yaml|yml)$/i"
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockstore.cwl" />
@@ -312,7 +312,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditWDL"
-                  ng-submit="submitDescriptorEdits()">
+                  ng-submit="submitDescriptorEdits('wdl')">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -208,7 +208,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditDockerfile"
-                  ng-submit="submitDescriptorEdits('dockerfile')">
+                  ng-submit="submitDescriptorEdits()">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
@@ -260,7 +260,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditCWL"
-                  ng-submit="submitDescriptorEdits('cwl')">
+                  ng-submit="submitDescriptorEdits()">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
@@ -312,7 +312,7 @@
             <form name="editContainerForm"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditWDL"
-                  ng-submit="submitDescriptorEdits('wdl')">
+                  ng-submit="submitDescriptorEdits()">
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -205,15 +205,22 @@
               </button>
             </div>
           <!-- for when it's edit mode and Edit button clicked-->
-            <form name="editContainerForm"
+            <form name="editDockerfilePath"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditDockerfile"
                   ng-submit="submitDescriptorEdits('dockerfile')">
+              <div
+                  class="form-error-messages"
+                  ng-messages="editDockerfilePath.contDockerfilePath.$error"
+                  ng-if="editDockerfilePath.contDockerfilePath.$touched">
+                <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
+                </div>
+              </div>
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
                       ng-click="showEditDockerfile = true"
-                      ng-disabled="editContainerForm.$invalid">
+                      ng-disabled="editDockerfilePath.contDockerfilePath.$invalid || refreshingContainer">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
               <div ng-show="!showEditDockerfile">
@@ -222,19 +229,12 @@
                   <input
                       type="text"
                       class="input-default form-control"
-                      name="contDescPath"
+                      name="contDockerfilePath"
                       ng-model="containerObj.default_dockerfile_path"
                       ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*Dockerfile$/i"
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockerfile" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/dockerfilepath.html">
-                    </div>
-                  </div>
                 </div>
               </div>
             </form>
@@ -257,15 +257,22 @@
               </button>
             </div>
             <!-- for when it's edit mode and Edit button clicked-->
-            <form name="editContainerForm"
+            <form name="editCWLPath"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditCWL"
                   ng-submit="submitDescriptorEdits('cwl')">
+              <div
+                  class="form-error-messages"
+                  ng-messages="editCWLPath.contCWLPath.$error"
+                  ng-if="editCWLPath.contCWLPath.$touched">
+                <div ng-messages-include="templates/validation/containers/cwlpath.html">
+                </div>
+              </div>
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
                       ng-click="showEditCWL = true"
-                      ng-disabled="editContainerForm.$invalid">
+                      ng-disabled="editCWLPath.contCWLPath.$invalid || refreshingContainer">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
               <div ng-show="!showEditCWL">
@@ -274,19 +281,12 @@
                   <input
                       type="text"
                       class="input-default form-control"
-                      name="contDescPath"
+                      name="contCWLPath"
                       ng-model="containerObj.default_cwl_path"
                       ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|yaml|yml)$/i"
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockstore.cwl" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/descriptorpath.html">
-                    </div>
-                  </div>
                 </div>
               </div>
             </form>
@@ -309,15 +309,22 @@
               </button>
             </div>
             <!-- for when it's edit mode and Edit button clicked-->
-            <form name="editContainerForm"
+            <form name="editWDLPath"
                   class="edit-container form-inline"
                   ng-show="editMode && !showEditWDL"
                   ng-submit="submitDescriptorEdits('wdl')">
+              <div
+                  class="form-error-messages"
+                  ng-messages="editWDLPath.contWDLPath.$error"
+                  ng-if="editWDLPath.contWDLPath.$touched">
+                <div ng-messages-include="templates/validation/containers/descriptorpath.html">
+                </div>
+              </div>
               <button type="submit"
                       class="btn btn-link pull-right"
                       style="padding: 3px 12px!important;"
                       ng-click="showEditWDL = true"
-                      ng-disabled="editContainerForm.$invalid">
+                      ng-disabled="editWDLPath.contWDLPath.$invalid || refreshingContainer">
                 <span class="glyphicon glyphicon-floppy-save"></span>Save
               </button>
               <div ng-show="!showEditWDL">
@@ -326,19 +333,12 @@
                   <input
                       type="text"
                       class="input-default form-control"
-                      name="contDescPath"
+                      name="contWDLPath"
                       ng-model="containerObj.default_wdl_path"
                       ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.wdl$/i"
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockstore.wdl" />
-                  <div
-                      class="form-error-messages"
-                      ng-messages="editContainerForm.contLabels.$error"
-                      ng-if="editContainerForm.contLabels.$touched">
-                    <div ng-messages-include="templates/validation/containers/descriptorpath.html">
-                    </div>
-                  </div>
                 </div>
               </div>
             </form>

--- a/app/templates/validation/containers/cwlpath.html
+++ b/app/templates/validation/containers/cwlpath.html
@@ -8,5 +8,5 @@
   Descriptor Path is too long. (Max 256 characters.)
 </p>
 <p ng-message="pattern">
-  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.wdl'.
+  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', or'*.yaml'.
 </p>


### PR DESCRIPTION
Same as the workflow pull request: https://github.com/ga4gh/dockstore-ui/pull/64 
Related issue: https://github.com/ga4gh/dockstore/issues/328, https://github.com/ga4gh/dockstore/issues/332
Related pull request: https://github.com/ga4gh/dockstore/pull/333

- The only difference between tool and workflow is that tool has three different fields(Dockerfile, CWL path and WDL path). In tool, either one of cwl/wdl path can be empty, as long as Dockerfile is there. However, as described in issue 332, currently what happens is if one of the descriptor path is blank or empty, there will be warning on the GUI side, and NullPointerException on the webservice side.
- Blank path check is added on the GUI side, that if for example, the CWL path is empty, and the user is trying to put WDL path empty, it will be automatically  changed back to '/Dockstore.wdl'. This will go the same for WDL path is already empty and the user is trying to put CWL path empty too.
- Dockerfile is set to cannot be empty, if the user put blank and hit Save, it will be automatically changed back to '/Dockerfile'
- Uppercase extension is allowed, since we tested that cwltool will still run the code if the extension is uppercase. The only thing is that, in Version tab, the file will be invalid. This will make Tool and DAG tab to show blank as these two depend on the validity of the files'. Descriptor tab will still show the file according to what's on the repo (e.g showing content of /Dockstore.cwl even though the default path is /Dockstore.CWL)