### PR TITLE
Feature/dockstore 330 path column

### DIFF
--- a/app/templates/versionsgrid.html
+++ b/app/templates/versionsgrid.html
@@ -3,49 +3,42 @@
     <table class="table versions-grid table-bordered table-condensed table-striped">
       <thead>
         <tr>
-          <th style="width: 8.5% !important;">
+          <th style="width:7.5% !important">
             Tag
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('name')"
                   ng-click="clickSortColumn('name')">
             </span>
           </th>
-          <th style="width: 13% !important;">
+          <th style="width:14.5% !important">
             Git Reference
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('reference')"
                   ng-click="clickSortColumn('reference')">
             </span>
           </th>
-          <th style="width: 10% !important">
+          <th style="width:21.5% !important">
             Tool Path
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('name')"
                   ng-click="clickSortColumn('name')">
             </span>
           </th>
-          <th style="width: 10.5% !important">
-            Size
-            <span class="glyphicon pull-right"
-                  ng-class="getIconClass('size')"
-                  ng-click="clickSortColumn('size')">
-            </span>
-          </th>
-          <th style="width: 15% !important;">
+          <th style="width:16.5% !important">
             Date Modified
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('last_modified')"
                   ng-click="clickSortColumn('last_modified')">
             </span>
           </th>
-          <th>
+          <th style="width:9.5% !important">
             Valid
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('valid')"
                   ng-click="clickSortColumn('valid')">
             </span>
           </th>
-          <th style="width: 3.5% !important;">
+          <th>
             Actions
           </th>
           <th>
@@ -61,7 +54,7 @@
         </tr>
         <tr ng-repeat="versionTag in (filteredVersionTags = (versionTags | HiddenTagsFilter:editMode | orderBy:sortColumn:sortReverse))" ng-hide="!editMode && versionTag.hidden">
           <td>
-            {{versionTag.name}}
+            <span>{{versionTag.name}}</span>
           </td>
           <td>
             <div class="git-ref">
@@ -69,12 +62,15 @@
             </span>
           </td>
           <td>
-            <span>{{versionTag.cwl_path}}</span>
-            <span>{{versionTag.wdl_path}}</span>
-            <span>{{versionTag.dockerfile_path}}</span>
-          </td>
-          <td>
-            {{getHRSize(versionTag.size)}}
+            <div style="border-bottom:1.5px solid #ddd;margin-bottom:6px;">
+              {{versionTag.cwl_path}}
+            </div>
+            <div style="border-bottom:1.5px solid #ddd;margin-bottom:6px;">
+              {{versionTag.wdl_path}}
+            </div>
+            <div>
+              {{versionTag.dockerfile_path}}
+            </div>
           </td>
           <td>
             {{getDateModified(versionTag.last_modified)}}

--- a/app/templates/versionsgrid.html
+++ b/app/templates/versionsgrid.html
@@ -3,28 +3,35 @@
     <table class="table versions-grid table-bordered table-condensed table-striped">
       <thead>
         <tr>
-          <th>
+          <th style="width: 8.5% !important;">
             Tag
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('name')"
                   ng-click="clickSortColumn('name')">
             </span>
           </th>
-          <th>
+          <th style="width: 13% !important;">
             Git Reference
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('reference')"
                   ng-click="clickSortColumn('reference')">
             </span>
           </th>
-          <th>
+          <th style="width: 10% !important">
+            Tool Path
+            <span class="glyphicon pull-right"
+                  ng-class="getIconClass('name')"
+                  ng-click="clickSortColumn('name')">
+            </span>
+          </th>
+          <th style="width: 10.5% !important">
             Size
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('size')"
                   ng-click="clickSortColumn('size')">
             </span>
           </th>
-          <th>
+          <th style="width: 15% !important;">
             Date Modified
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('last_modified')"
@@ -38,7 +45,7 @@
                   ng-click="clickSortColumn('valid')">
             </span>
           </th>
-          <th>
+          <th style="width: 3.5% !important;">
             Actions
           </th>
           <th>
@@ -60,6 +67,11 @@
             <div class="git-ref">
               {{versionTag.reference ? versionTag.reference : 'n/a'}}
             </span>
+          </td>
+          <td>
+            <span>{{versionTag.cwl_path}}</span>
+            <span>{{versionTag.wdl_path}}</span>
+            <span>{{versionTag.dockerfile_path}}</span>
           </td>
           <td>
             {{getHRSize(versionTag.size)}}

--- a/app/templates/workflowversionsgrid.html
+++ b/app/templates/workflowversionsgrid.html
@@ -18,6 +18,13 @@
             </span>
         </th>
         <th>
+          Workflow Path
+            <span class="glyphicon pull-right"
+                  ng-class="getIconClass('workflow_path')"
+                  ng-click="clickSortColumn('workflow_path')">
+            </span>
+        </th>
+        <th>
           Date Modified
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('last_modified')"
@@ -51,6 +58,9 @@
             {{versionTag.reference ? versionTag.reference : 'n/a'}}
             </span>
           </div>
+        </td>
+        <td>
+          {{versionTag.workflow_path}}
         </td>
         <td>
           {{getDateModified(versionTag.last_modified)}}


### PR DESCRIPTION
- Workflows: Workflow path column is added to the Version tab
- Tools: Tool path column is added to the Version tab
    - "Size" column is not part of Version tab anymore for Tools, but still can be seen when Edit is clicked and Tag editor dialog is shown
    - Some of the columns in the Version tab have to be manually changed (in order to fit the new changes added) because the class used is part of bootstrap css, and we dont want to alter that file
    - Border is added to separate cwl, wdl and dockerfile path

It will look something like this for Tools:
![screenshot from 2016-07-15 13 23 19](https://cloud.githubusercontent.com/assets/6503391/16882926/7bf0d0ce-4a8f-11e6-8e7b-4230f3e3ba2a.png)

