### PR TITLE
Feature/default version support

### DIFF
--- a/app/scripts/controllers/versionsgrid.js
+++ b/app/scripts/controllers/versionsgrid.js
@@ -92,4 +92,11 @@ angular.module('dockstore.ui')
         };
       };
 
+      $scope.updateDefaultVersion = function(referenceName) {
+      $scope.containerObj.defaultValue = referenceName;
+        ContainerService.updateDefaultVersion($scope.containerObj.id,$scope.containerObj)
+        .then(function(){
+          $scope.$parent.refreshContainer($scope.containerObj.id,0);
+         });
+      };
   }]);

--- a/app/scripts/controllers/workflowversionsgrid.js
+++ b/app/scripts/controllers/workflowversionsgrid.js
@@ -44,5 +44,13 @@ angular.module('dockstore.ui')
         $scope.versionTags.push(tagObj);
       };
 
+      $scope.updateDefaultVersion = function(referenceName) {
+      $scope.workflowObj.defaultValue = referenceName;
+        WorkflowService.updateDefaultVersion($scope.workflowObj.id,$scope.workflowObj)
+        .then(function(){
+          $scope.$parent.refreshWorkflow($scope.workflowObj.id,0);
+         });
+      };
+
 
   }]);

--- a/app/scripts/services/containerservice.js
+++ b/app/scripts/services/containerservice.js
@@ -239,7 +239,7 @@ angular.module('dockstore.ui')
       });
     };
 
-    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
+    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274
     this.setDefaultToolPath = function(containerId,cwlPath,wdlPath,dfPath,toolname,giturl){
       return $q(function(resolve, reject) {
         $http({
@@ -343,6 +343,21 @@ angular.module('dockstore.ui')
             });
           });
         };
+
+
+    this.updateDefaultVersion = function(containerId,toolObj){
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'PUT',
+          url: WebService.API_URI + '/containers/' + containerId,
+          data: toolObj
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
 
 
   }]);

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -300,4 +300,18 @@ angular.module('dockstore.ui')
       });
     };
 
+    this.updateDefaultVersion = function(workflowId,workflowObj){
+      return $q(function(resolve, reject) {
+        $http({
+          method: 'PUT',
+          url: WebService.API_URI + '/workflows/' + workflowId,
+          data: workflowObj
+        }).then(function(response) {
+          resolve(response.data);
+        }, function(response) {
+          reject(response);
+        });
+      });
+    };
+
   }]);

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -864,4 +864,9 @@ div.tabs > div:target > div, :target #info > div, #info > div {
   height: 300px;
   width: 100%;
 }
+
+.radio-button-reference {
+  margin-top: -1px;
+  vertical-align: middle;
+}
 /* End Temporary Styles - Need to Refactor Later */

--- a/app/templates/versionsgrid.html
+++ b/app/templates/versionsgrid.html
@@ -58,7 +58,7 @@
           </td>
           <td>
             <div class="git-ref">
-              <input ng-if="editMode && versionTag.name !== 'latest'" type="radio" name="defaultVersion" ng-model="$parent.containerObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
+              <input class="radio-button-reference" ng-if="editMode && versionTag.name !== 'latest'" type="radio" name="defaultVersion" ng-model="$parent.containerObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
               {{versionTag.reference ? versionTag.reference : 'n/a'}}
             </div>
           </td>

--- a/app/templates/versionsgrid.html
+++ b/app/templates/versionsgrid.html
@@ -3,14 +3,14 @@
     <table class="table versions-grid table-bordered table-condensed table-striped">
       <thead>
         <tr>
-          <th style="width:7.5% !important">
+          <th style="width:10.5% !important">
             Tag
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('name')"
                   ng-click="clickSortColumn('name')">
             </span>
           </th>
-          <th style="width:14.5% !important">
+          <th style="width:8% !important">
             Git Reference
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('reference')"
@@ -31,14 +31,14 @@
                   ng-click="clickSortColumn('last_modified')">
             </span>
           </th>
-          <th style="width:9.5% !important">
+          <th style="width:7.5% !important">
             Valid
             <span class="glyphicon pull-right"
                   ng-class="getIconClass('valid')"
                   ng-click="clickSortColumn('valid')">
             </span>
           </th>
-          <th>
+          <th style="width:6.5% !important">
             Actions
           </th>
           <th>
@@ -58,8 +58,9 @@
           </td>
           <td>
             <div class="git-ref">
+              <input ng-if="editMode && versionTag.name !== 'latest'" type="radio" name="defaultVersion" ng-model="$parent.containerObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
               {{versionTag.reference ? versionTag.reference : 'n/a'}}
-            </span>
+            </div>
           </td>
           <td>
             <div style="border-bottom:1.5px solid #ddd;margin-bottom:6px;">

--- a/app/templates/workflowversionsgrid.html
+++ b/app/templates/workflowversionsgrid.html
@@ -55,6 +55,7 @@
         </td>
         <td>
           <div class="git-ref">
+            <input ng-if="editMode" type="radio" name="defaultVersion" ng-model="$parent.workflowObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
             {{versionTag.reference ? versionTag.reference : 'n/a'}}
             </span>
           </div>

--- a/app/templates/workflowversionsgrid.html
+++ b/app/templates/workflowversionsgrid.html
@@ -55,7 +55,7 @@
         </td>
         <td>
           <div class="git-ref">
-            <input ng-if="editMode" type="radio" name="defaultVersion" ng-model="$parent.workflowObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
+            <input class="radio-button-reference" ng-if="editMode" type="radio" name="defaultVersion" ng-model="$parent.workflowObj.defaultVersion" ng-value="versionTag.reference" ng-click="updateDefaultVersion(versionTag.reference)"/>
             {{versionTag.reference ? versionTag.reference : 'n/a'}}
             </span>
           </div>

--- a/app/views/containereditor.html
+++ b/app/views/containereditor.html
@@ -64,7 +64,7 @@
     <div class="col-md-3 containers-rsb">
       <div class="ns-containers-accordion" ng-if="nsContainers">
         <uib-accordion close-others="true">
-          <uib-accordion-group ng-repeat="nsObj in nsContainers" is-open="nsContainers[$index].isOpen">
+          <uib-accordion-group ng-repeat="nsObj in nsContainers" is-open="$first">
             <uib-accordion-heading>
               <div class="container-namespace-label-oflw"
                   title="{{nsObj.namespace}}"

--- a/app/views/workfloweditor.html
+++ b/app/views/workfloweditor.html
@@ -63,7 +63,7 @@
     <div class="col-md-3 containers-rsb">
       <div class="ns-containers-accordion">
         <uib-accordion close-others="true">
-          <uib-accordion-group ng-repeat="orgObj in orgWorkflows" is-open="orgWorkflows[$index].isOpen">
+          <uib-accordion-group ng-repeat="orgObj in orgWorkflows" is-open="$first">
             <uib-accordion-heading>
               <div class="container-namespace-label-oflw"
                    title="{{orgObj.organization}}"


### PR DESCRIPTION
This adds support for setting the default version for a tool and workflow based off of the associated CWL file.

[X] Check that you pass the basic compilation and unit tests by running `grunt` 
