### PR TITLE
Feature/update docs flags and mac

### DIFF
--- a/app/docs/advanced-features.md
+++ b/app/docs/advanced-features.md
@@ -16,3 +16,12 @@ cache-dir =
 The former is false by default and can be set to true in order to activate the cache. 
 The latter is `~/.dockstore/cache/` by default and can be set to any directory location.
 
+## Running CWL-runner with extra tags
+
+When running a CWL tool, you may want to add additional parameters/flags to the cwl-runner command. You can do this by updating your dockstore config file (~/.dockstore/config).
+
+As an example, adding the following line to your config file will stop cwl-runner from cleaning up, make it run in debug mode, and set the outdir to '/new/outputdir'
+
+```
+cwltool-extra-parameters: --debug, --leave-container, --leave-tmpdir, --outdir /new/outputdir
+```

--- a/app/docs/faq.md
+++ b/app/docs/faq.md
@@ -40,7 +40,17 @@ Additionally:
 * genomics workflows work with large data files, this can have a few ramifications:
     * do not "package" large data reference files in your Docker image.  Instead, treat them as "inputs" so they can be stagged outside and mounted into the running container
     * the `$TMPDIR` variable can be used as a scratch space inside your container.  Make sure your host running Docker has sufficient scratch space for processing your genomics data.
-    
+ 
+## How do I use the Dockstore CLI on a Mac?
+Use [Docker for Mac](https://docs.docker.com/engine/installation/mac/)
+
+Note:
+Docker behaves a bit differently on a [mac](https://docs.docker.com/docker-for-mac/osxfs/#/namespaces) than on a typical ubuntu machine. By default the only shared volumes are /Users, /Volumes, /tmp, /private. Note that /var is not a shared directory (and can't be set as one). CWLtool uses your TMPDIR (the env variable) to setup volumes with docker, which on a Mac can default to a subdirectory of /var. In order to get CWLtool working on your mac, you need to set your TMPDIR to be under one of the shared volumes in Docker for Mac. You can do this by doing something like the following:
+
+```
+export TMPDIR=/tmp/docker_tmp
+```
+
 ## Any last tips on using Dockstore?
 
 * the Dockstore CLI uses `./datastore` for temp files so if you're processing large files make sure this partition hosting the current directory is large.

--- a/app/docs/faq.md
+++ b/app/docs/faq.md
@@ -45,7 +45,7 @@ Additionally:
 Use [Docker for Mac](https://docs.docker.com/engine/installation/mac/)
 
 Note:
-Docker behaves a bit differently on a [mac](https://docs.docker.com/docker-for-mac/osxfs/#/namespaces) than on a typical ubuntu machine. By default the only shared volumes are /Users, /Volumes, /tmp, /private. Note that /var is not a shared directory (and can't be set as one). CWLtool uses your TMPDIR (the env variable) to setup volumes with docker, which on a Mac can default to a subdirectory of /var. In order to get CWLtool working on your mac, you need to set your TMPDIR to be under one of the shared volumes in Docker for Mac. You can do this by doing something like the following:
+Docker behaves a bit differently on a [mac](https://docs.docker.com/docker-for-mac/osxfs/#/namespaces) than on a typical ubuntu machine. By default the only shared volumes are /Users, /Volumes, /tmp, and /private. Note that /var is not a shared directory (and can't be set as one). CWLtool uses your TMPDIR (the env variable) to setup volumes with docker, which on a Mac can default to a subdirectory of /var. In order to get CWLtool working on your mac, you need to set your TMPDIR to be under one of the shared volumes in Docker for Mac. You can do this by doing something similar to the following:
 
 ```
 export TMPDIR=/tmp/docker_tmp


### PR DESCRIPTION
Updates docs to include information for using dockstore CLI with mac and how to use extra cwltool flags.

- [x] Check that you pass the basic compilation and unit tests by running `grunt` 
