### PR TITLE
Feature/issue 572

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,9 @@ before_script:
   - java -jar dockstore-webservice-${WEBSERVICE_VERSION}.jar server travisci/web.yml 1>/dev/null &
   - 'sleep 20'
 
+after_success:
+  - bash deploy.sh
+
 script:
   - cypress ci #test using cypress for integration testing
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,7 +50,9 @@ module.exports = function (grunt) {
 
   // Define the configuration for all the tasks
   grunt.initConfig({
-
+    ngdocs: {
+      all: ['app/**/*.js']
+    },
     branch: execSync("git rev-parse --abbrev-ref HEAD  | xargs echo -n"),
     banner: "/*!\n <%= grunt.template.today('dddd, mmmm dS, yyyy, h:MM:ss TT') %>\n branch: <%= branch %>\n revision: "+gitRev+"\n */\n",
 
@@ -468,12 +470,7 @@ module.exports = function (grunt) {
           match: "<!-- git version -->"
       }
     },
-    ngdocs: {
-	all: ['app/scripts/**/*.js']
-    }
-
   });
-  grunt.loadNpmTasks('grunt-ngdocs');
 
   grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
     if (target === 'dist') {
@@ -487,8 +484,7 @@ module.exports = function (grunt) {
       'autoprefixer:server',
       'copy:styles',
       'connect:livereload',
-      'watch',
-      'grunt-ngdocs'
+      'watch'
     ]);
   });
 
@@ -504,6 +500,8 @@ module.exports = function (grunt) {
     'autoprefixer',
     'connect:test'
   ]);
+
+  grunt.loadNpmTasks('grunt-ngdocs');
 
   grunt.registerTask('build', function(target){
 
@@ -533,10 +531,9 @@ module.exports = function (grunt) {
       'cache_control'
     ]);
   });
-
+  grunt.registerTask('createDocs', ['ngdocs']);
   grunt.registerTask('default', [
     'newer:jshint',
-    'build',
-    'ngdocs'
+    'build'
   ]);
 };

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,6 +4,8 @@ set -o errexit -o nounset
 
 if [ ! -z "$TRAVIS_TAG" ]
 then
+  echo "Building ngdocs.  $TRAVIS_TAG is a new tag"
+else
   echo "This commit was made against the $TRAVIS_BRANCH and not a tag"
   exit 0
 fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit -o nounset
+
+if [ "$TRAVIS_BRANCH" != "feature/issue-572" ]
+then
+  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  exit 0
+fi
+
+rev=$(git rev-parse --short HEAD)
+grunt ngdocs
+cd docs
+git init
+git config user.name "garyluu"
+git config user.email "garylau.work@gmail.com"
+
+git remote add upstream "https://$GH_TOKEN@github.com/ga4gh/dockstore-ui.git"
+git fetch upstream
+git reset upstream/gh-pages
+
+touch .
+
+echo "ngdocs.com" > CNAME
+
+git add -A .
+git commit -m "rebuild pages at ${rev}"
+git push -q upstream HEAD:gh-pages

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,9 +2,9 @@
 
 set -o errexit -o nounset
 
-if [ "$TRAVIS_BRANCH" != "feature/issue-572" ]
+if [ ! -z "$TRAVIS_TAG" ]
 then
-  echo "This commit was made against the $TRAVIS_BRANCH and not the master! No deploy!"
+  echo "This commit was made against the $TRAVIS_BRANCH and not a tag"
   exit 0
 fi
 
@@ -20,8 +20,6 @@ git fetch upstream
 git reset upstream/gh-pages
 
 touch .
-
-echo "ngdocs.com" > CNAME
 
 git add -A .
 git commit -m "rebuild pages at ${rev}"


### PR DESCRIPTION
Adding a deploy.sh that runs after successful testing on Travis.  Deploy.sh runs grunt-ngdocs and pushes the docs to the gh-pages branch on dockstore-ui only when it's a tag build/pull request.  The docs can be viewed at https://ga4gh.github.io/dockstore-ui/