### PR TITLE
Break words for star panel headers

### DIFF
--- a/app/templates/starredentries.html
+++ b/app/templates/starredentries.html
@@ -17,6 +17,9 @@ h5.panel-title {
 h6.panel-title {
     font-size: 10px;
 }
+.panel-title {
+  word-break:break-all;
+}
 </style>
 
 <div id="container-header">


### PR DESCRIPTION
Fix for ga4gh/dockstore#668.  Break all words when wrapping.