### PR TITLE
Only showing description when it exists

### DIFF
--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -374,7 +374,7 @@
             <div class="well well-sm">
               <span class = "glyphicon glyphicon-warning-sign"></span>
               <span ng-show="!containerObj.description">
-                No description associated with this container.  Please add a description.
+                No description associated with this tool.  See <a href="https://dockstore.org/docs/getting-started-with-cwl">Dockstore's Getting Started With CWL</a> and <a href="http://www.commonwl.org/v1.0/CommandLineTool.html#CommandLineTool">commonwl.org</a> for how to define a description for this tool.
               </span>
             </div>
           </li>

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -368,8 +368,13 @@
                 ng-show="containerObj.description"
                 marked="containerObj.description">
               </div>
+            </div>
+          </li>
+          <li ng-show="!containerObj.description && editMode">
+            <div class="well well-sm">
+              <span class = "glyphicon glyphicon-warning-sign"></span>
               <span ng-show="!containerObj.description">
-                No description associated with this container. Please select a version.
+                No description associated with this container.  Please add a description.
               </span>
             </div>
           </li>

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -361,7 +361,7 @@
             <strong uib-tooltip="Date and time of the last update to the Tool entry">Last Update</strong>:
             {{ containerObj.lastUpdated ? getDateTimeString(containerObj.lastUpdated) : 'n/a' }}
           </li>
-          <li>
+          <li ng-show="containerObj.description">
             <strong uib-tooltip="Description of tool obtained from tool descriptor">Description</strong>:
             <div class="well well-sm">
               <div


### PR DESCRIPTION
This fixes issue ga4gh/dockstore#694 by not showing the entire description section if the containerObj contains no description.