### PR TITLE
Feature/package json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
   - 'npm install --global grunt-cli bower yo generator-karma generator-angular'
   - 'sudo apt-get install -y ruby ruby-dev make'
   - 'gem install compass'
-  - 'npm update'
+  - 'npm install'
   - 'bower update'
 
 before_script:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dockstore.ui",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "connect-modrewrite": "0.9.0",
     "grunt": "0.4.5",
     "grunt-angular-templates": "1.1.0",
@@ -11,14 +11,12 @@
     "grunt-contrib-clean": "1.0.0",
     "grunt-contrib-compass": "1.1.1",
     "grunt-contrib-concat": "1.0.1",
-    "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-copy": "1.0.0",
     "grunt-contrib-cssmin": "1.0.2",
     "grunt-contrib-htmlmin": "2.2.0",
     "grunt-contrib-imagemin": "1.0.1",
     "grunt-contrib-jshint": "1.1.0",
     "grunt-contrib-uglify": "2.1.0",
-    "grunt-contrib-watch": "1.0.0",
     "grunt-filerev": "2.3.1",
     "grunt-google-cdn": "0.4.3",
     "grunt-insert": "0.1.0",
@@ -39,5 +37,8 @@
   "scripts": {
     "test": "grunt test & cypress run"
   },
-  "dependencies": {}
+  "devDependencies": {
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-contrib-connect": "1.0.2"
+  }
 }


### PR DESCRIPTION
- All dependencies needed for "grunt" is now in "dependencies"
- Additional dependencies only needed for "grunt serve" remains in "devDependencies"
- "npm update" changed to "npm install" because "npm update" does not install devDependencies anymore with nodejs v8.0.0, but "npm install" does.
